### PR TITLE
Initial PR for scribbleFloodfill algorithm

### DIFF
--- a/src/main/ngapp/accio/src/app/editor/magic-wand.service.spec.ts
+++ b/src/main/ngapp/accio/src/app/editor/magic-wand.service.spec.ts
@@ -30,7 +30,7 @@ describe('MagicWandService', () => {
     imgData.data[56 + 2] = 117;  // Blue
     imgData.data[56 + 3] = 255;  // Alpha
     expect(service.dataArrayToRgba(
-        imgData, 3, 1)).toEqual([120, 111, 117, 255]);
+        imgData, 3, 1)).toEqual([120, 111, 117]);
   });
   it('Test method: isInBounds() >> top left OutOfRange', () => {
     // Should return false if inputted pixel's coord is out of range of the img
@@ -68,7 +68,7 @@ describe('MagicWandService', () => {
     const imgData: ImageData = makeTestImage(
         11, 4, [120, 117, 108, 255], new Set<number>([24]));
     expect(service.getIsMask(
-        [131, 117, 108, 255], imgData, [6, 0], 10)).toEqual(
+        [131, 117, 108], imgData, [6, 0], 10)).toEqual(
         false);
   });
   it('Test method: getIsMask() >> valid', () => {
@@ -76,7 +76,7 @@ describe('MagicWandService', () => {
     const imgData: ImageData = makeTestImage(
         11, 4, [120, 117, 108, 255], new Set<number>([24]));
     expect(service.getIsMask(
-        [130, 117, 108, 255], imgData, [6, 0], 10)).toEqual(
+        [130, 117, 108], imgData, [6, 0], 10)).toEqual(
         true);
   });
   it('Test method: floodfill() >> no adjacent pixels in mask', () => {

--- a/src/main/ngapp/accio/src/app/editor/magic-wand.service.spec.ts
+++ b/src/main/ngapp/accio/src/app/editor/magic-wand.service.spec.ts
@@ -105,33 +105,79 @@ describe('MagicWandService', () => {
 
   // Test suite for additional tools
   it('Test method: erase()', () => {
-  // Should return a mask with pixels from the input set being excluded
-  const originalMask: Set<number> = new Set([0, 8, 12, 40, 44]);
-  const mistake: Set<number> = new Set([12, 40]);
-  const expected: Set<number> = new Set([0, 8, 44]);
-  expect(service.erase(originalMask, mistake)).toEqual(expected);
+    // Should return a mask with pixels from the input set being excluded
+    const originalMask: Set<number> = new Set([0, 8, 12, 40, 44]);
+    const mistake: Set<number> = new Set([12, 40]);
+    const expected: Set<number> = new Set([0, 8, 44]);
+    expect(service.erase(originalMask, mistake)).toEqual(expected);
   });
   it('Test method: invert()', () => {
-  // Should return a mask with pixels from the input set being excluded
-  const originalMask: Set<number> = new Set([0, 8, 12, 40, 44]);
-  const expected: Set<number> = new Set([4, 16, 20, 24, 28, 32, 36]);
-  expect(service.invert(originalMask, 4, 3)).toEqual(expected);
+    // Should return a mask with pixels from the input set being excluded
+    const originalMask: Set<number> = new Set([0, 8, 12, 40, 44]);
+    const expected: Set<number> = new Set([4, 16, 20, 24, 28, 32, 36]);
+    expect(service.invert(originalMask, 4, 3)).toEqual(expected);
   });
 
   it('Test method: rgbEuclideanDist() valid', () => {
-  // Should return the straight line distance between two pixels' colors
-  const pixelA = [2, 4, 1];
-  const pixelB = [7, 2, 2];
-  // Euclidean distance is the sqrt( sum( a[n] - b[n] ) )
-  expect(service.rgbEuclideanDist(pixelA, pixelB)).toEqual(30);
+    // Should return the straight line distance between two pixels' colors
+    const pixelA = [2, 4, 1];
+    const pixelB = [7, 2, 2];
+    // Euclidean distance is the sqrt( sum( a[n] - b[n] ) )
+    expect(service.rgbEuclideanDist(pixelA, pixelB)).toEqual(30);
   });
   it('rbgEuclideanDist() Error(arrays different length)', () => {
-  expect(() => {service.rgbEuclideanDist([1, 2, 3], [4, 2])}).toThrow(
-      new Error('basisColor and secondColor must be same lengthed arrays...'));
+    expect(() => {service.rgbEuclideanDist([1, 2, 3], [4, 2])}).toThrow(
+        new Error(
+        'basisColor and secondColor must be same lengthed arrays...'));
   });
   it('rbgEuclideanDist() Error(length must be 3)', () => {
-  expect(() => {service.rgbEuclideanDist([1, 2], [4, 2])}).toThrow(
-      new Error('Arguments must be an array of [R, G, B] (length == 3)...'));
+    expect(() => {service.rgbEuclideanDist([1, 2], [4, 2])}).toThrow(
+        new Error('Arguments must be an array of [R, G, B] (length == 3)...'));
+  });
+
+  it('Test method: pixelIndexToXYCoord()', () => {
+    expect(service.pixelIndexToXYCoord(8, 4)).toEqual([2, 0]);
+    expect(service.pixelIndexToXYCoord(148, 11)).toEqual([4, 3]);
+  });
+  it('Test method: getIsScribbleMask() true', () => {
+    const imgData: ImageData = makeTestImage(
+        4, 4, [255, 255, 255, 255], new Set<number>(
+        [8, 12, 16]));
+
+    expect(service.getIsScribbleMask(
+        new Set<number>([4, 8]), imgData, [1, 0], 5)).toEqual(
+        true);
+    expect(service.getIsScribbleMask(
+        new Set<number>([4, 8]), imgData, [2, 0], 5)).toEqual(
+        true);
+  });
+  it('Test method: getIsScribbleMask() false', () => {
+    const imgData: ImageData = makeTestImage(
+        4, 4, [255, 255, 255, 255], new Set<number>(
+        [8, 12, 16]));
+    imgData.data[20] = 120;
+    imgData.data[20 + 1] = 120;
+    imgData.data[20 + 2] = 120;
+    imgData.data[20 + 3] = 120;
+
+    expect(service.getIsScribbleMask(
+        new Set<number>([4, 8]), imgData, [1, 1], 5)).toEqual(
+        false);
+  });
+  it('Test method: scribbleFloodfill()', () => {
+    const imgData: ImageData = makeTestImage(
+        4, 4, [255, 255, 255, 255], new Set<number>(
+        [8, 12, 16]));
+    for (let i of [20, 24, 28, 32]) {
+      imgData.data[i] = 120;
+      imgData.data[i + 1] = 120;
+      imgData.data[i + 2] = 120;
+      imgData.data[i + 3] = 120;
+    }
+
+    expect(service.scribbleFloodfill(
+        imgData, 1, 0, 5, new Set<number>([4, 8]))).toEqual(
+        new Set<number>([0, 4, 8, 12, 16]));
   });
 });
 

--- a/src/main/ngapp/accio/src/app/editor/magic-wand.service.spec.ts
+++ b/src/main/ngapp/accio/src/app/editor/magic-wand.service.spec.ts
@@ -29,7 +29,7 @@ describe('MagicWandService', () => {
     imgData.data[56 + 1] = 111;  // Green
     imgData.data[56 + 2] = 117;  // Blue
     imgData.data[56 + 3] = 255;  // Alpha
-    expect(service.dataArrayToRgba(
+    expect(service.dataArrayToRgb(
         imgData, 3, 1)).toEqual([120, 111, 117]);
   });
   it('Test method: isInBounds() >> top left OutOfRange', () => {

--- a/src/main/ngapp/accio/src/app/editor/magic-wand.service.spec.ts
+++ b/src/main/ngapp/accio/src/app/editor/magic-wand.service.spec.ts
@@ -102,7 +102,8 @@ describe('MagicWandService', () => {
     expect(service.floodfill(imgData, 6, 1, 1)).toEqual(new Set<number>(
         [68, 72]));
   });
-// Test suite for additional tools
+
+  // Test suite for additional tools
   it('Test method: erase()', () => {
   // Should return a mask with pixels from the input set being excluded
   const originalMask: Set<number> = new Set([0, 8, 12, 40, 44]);
@@ -115,6 +116,22 @@ describe('MagicWandService', () => {
   const originalMask: Set<number> = new Set([0, 8, 12, 40, 44]);
   const expected: Set<number> = new Set([4, 16, 20, 24, 28, 32, 36]);
   expect(service.invert(originalMask, 4, 3)).toEqual(expected);
+  });
+
+  it('Test method: rgbEuclideanDist() valid', () => {
+  // Should return the straight line distance between two pixels' colors
+  const pixelA = [2, 4, 1];
+  const pixelB = [7, 2, 2];
+  // Euclidean distance is the sqrt( sum( a[n] - b[n] ) )
+  expect(service.rgbEuclideanDist(pixelA, pixelB)).toEqual(30);
+  });
+  it('rbgEuclideanDist() Error(arrays different length)', () => {
+  expect(() => {service.rgbEuclideanDist([1, 2, 3], [4, 2])}).toThrow(
+      new Error('basisColor and secondColor must be same lengthed arrays...'));
+  });
+  it('rbgEuclideanDist() Error(length must be 3)', () => {
+  expect(() => {service.rgbEuclideanDist([1, 2], [4, 2])}).toThrow(
+      new Error('Arguments must be an array of [R, G, B] (length == 3)...'));
   });
 });
 

--- a/src/main/ngapp/accio/src/app/editor/magic-wand.service.ts
+++ b/src/main/ngapp/accio/src/app/editor/magic-wand.service.ts
@@ -73,16 +73,13 @@ export class MagicWandService {
     const curX: number = pixelCoord[0];
     const curY: number = pixelCoord[1];
 
-    // Gets array of the color attributes of current pixel.
+    // Gets [R, G, B] of current pixel.
     const curPixel: Array<number> = this.dataArrayToRgba(imgData, curX, curY);
 
-    // Color attributes of pixel (R,G, and B) must be within tolerance level.
-    for (let i = 0; i < 3; i++) {
-      const upperTolerance: boolean = curPixel[i] > originalPixel[i] + tolerance;
-      const lowerTolerance: boolean = curPixel[i] < originalPixel[i] - tolerance;
-      if (upperTolerance || lowerTolerance) {
-        return false;
-      }
+    const colorDifference = this.rgbEuclideanDist(originalPixel, curPixel);
+
+    if (colorDifference > tolerance) {
+      return false;
     }
 
     return true;
@@ -92,7 +89,7 @@ export class MagicWandService {
    * @param {Array<number> [R, G, B]} basisColor and 
    * @param {Array<number> [R, G, B]} secondColor
    */
-  RgbEuclideanDist(basisColor: Array<number>, secondColor: Array<number>)
+  rgbEuclideanDist(basisColor: Array<number>, secondColor: Array<number>)
       : number {
     if (basisColor.length != secondColor.length) {
       throw new Error(

--- a/src/main/ngapp/accio/src/app/editor/magic-wand.service.ts
+++ b/src/main/ngapp/accio/src/app/editor/magic-wand.service.ts
@@ -252,7 +252,7 @@ export class MagicWandService {
         }
         // Visits the pixel and check if it should be part of the mask.
         visited.add(this.coordToDataArrayIndex(x, y, imgData.width));
-        if (this.getIsScribbleMask(originalPixel, imgData, neighborPixel, tolerance)) {
+        if (this.getIsScribbleMask(originalPixel, imgData, neighborPixel, tolerance, scribbles)) {
           visit.push(neighborPixel);
         }
       }
@@ -284,12 +284,22 @@ export class MagicWandService {
     return true;
   }
 
-  filterScribbles(scribbles: Set<number>, tolerance: number): Set<number> {
+  /**@returns {Set<number>} filtered set of pixels by removing indices 
+   * of pixels whose color are too similar to the original pixel. 
+   * Judgement of 'too similar' is decided by a factor of 
+   * @param {number} tolerance and color value itself is retrieved from
+   * @param {ImageData} imgData
+  */
+  filterScribbles(scribbles: Set<number>, originalPixel: Array<number>, 
+      imgData: ImageData, tolerance: number): Set<number> {
     // TODO
     let result: Set<number> = new Set();
     for (let pixelCoord of scribbles) {
-      pixelColor = RgbEuclideanDist();
-      if (/* filter condition */) {
+      const x = (pixelCoord / 4) % imgData.width;
+      const y = (pixelCoord / 4) / imgData.width;
+      const curPixel = this.dataArrayToRgba(imgData, x, y);
+      const colorDifference = this.rgbEuclideanDist(originalPixel, curPixel);
+      if (colorDifference > tolerance / 2) {
         result.add(pixelCoord);
       }
     }

--- a/src/main/ngapp/accio/src/app/editor/magic-wand.service.ts
+++ b/src/main/ngapp/accio/src/app/editor/magic-wand.service.ts
@@ -77,8 +77,10 @@ export class MagicWandService {
     const curPixel: Array<number> = this.dataArrayToRgb(imgData, curX, curY);
 
     const colorDifference = this.rgbEuclideanDist(originalPixel, curPixel);
+    // Work with tolerance logic in squared space for Euclidean distance.
+    const squaredTolerance = tolerance * tolerance;
 
-    if (colorDifference > tolerance) {
+    if (colorDifference > squaredTolerance) {
       return false;
     }
 
@@ -106,7 +108,10 @@ export class MagicWandService {
       distance += Math.pow((basisColor[i] - secondColor[i]), 2);
     }
 
-    return Math.sqrt(distance);
+    // Does not sqrt distance to complete eucidean dist formula b/c sqrt is
+    // an expense operation. Instead, can compare against tolerance in the 
+    // squared space.
+    return distance;
   } 
 
   // Checks if @pixelCoord is in bounds and makes sure it's not a repeat coord.
@@ -271,6 +276,8 @@ export class MagicWandService {
 
     // Gets array of color attributes of current pixel.
     const curPixel: Array<number> = this.dataArrayToRgb(imgData, curX, curY);
+    // Work with tolerance logic in squared space for Euclidean distance.
+    const squaredTolerance = tolerance * tolerance;
 
     for (let pixelIndex of scribbles) {
       const refPixelCoord: Array<number> = 
@@ -283,7 +290,7 @@ export class MagicWandService {
 
       // If the curPixel is tolerable for at least 1 of the reference pixels,
       // then the curPixel will be part of the mask.
-      if (colorDifference <= tolerance) {
+      if (colorDifference <= squaredTolerance) {
         return true;
       }
     }

--- a/src/main/ngapp/accio/src/app/editor/magic-wand.service.ts
+++ b/src/main/ngapp/accio/src/app/editor/magic-wand.service.ts
@@ -252,7 +252,7 @@ export class MagicWandService {
         }
         // Visits the pixel and check if it should be part of the mask.
         visited.add(this.coordToDataArrayIndex(x, y, imgData.width));
-        if (this.getIsScribbleMask(originalPixel, imgData, neighborPixel, tolerance, scribbles)) {
+        if (this.getIsScribbleMask(scribbles, imgData, neighborPixel, tolerance)) {
           visit.push(neighborPixel);
         }
       }
@@ -264,8 +264,8 @@ export class MagicWandService {
   /**Judges current pixel's RGB against original pixel's RGB to
    * see if it can still be part of the mask (using tolerance criteria).
    */
-  getIsScribbleMask(originalPixel: Array<number>, imgData: ImageData,
-      pixelCoord: Array<number>, tolerance: number, scribbles: Set<number>): boolean {
+  getIsScribbleMask(scribbles: Set<number>, imgData: ImageData,
+      pixelCoord: Array<number>, tolerance: number): boolean {
     const curX: number = pixelCoord[0];
     const curY: number = pixelCoord[1];
 

--- a/src/main/ngapp/accio/src/app/editor/magic-wand.service.ts
+++ b/src/main/ngapp/accio/src/app/editor/magic-wand.service.ts
@@ -38,10 +38,10 @@ export class MagicWandService {
       const x: number = coord[0];
       const y: number = coord[1];
 
-      // Operational part of while-loop...
+      // Operational part of while-loop.
       mask.add(this.coordToDataArrayIndex(x, y, imgData.width));
 
-      // Loop part of while-loop...
+      // Loop part of while-loop.
 
       // Gets coords of adjacent pixels.
       const neighbors: Array<Array<number>> =
@@ -60,7 +60,7 @@ export class MagicWandService {
           visit.push(neighborPixel);
         }
       }
-    }  // End of while loop...
+    }  // End of while loop.
 
     return mask;
   }
@@ -234,10 +234,10 @@ export class MagicWandService {
       const x: number = coord[0];
       const y: number = coord[1];
 
-      // Operational part of while-loop...
+      // Operational part of while-loop.
       mask.add(this.coordToDataArrayIndex(x, y, imgData.width));
 
-      // Loop part of while-loop...
+      // Loop part of while-loop.
 
       // Gets coords of adjacent pixels.
       const neighbors: Array<Array<number>> =
@@ -256,7 +256,7 @@ export class MagicWandService {
           visit.push(neighborPixel);
         }
       }
-    }  // End of while loop...
+    }  // End of while loop.
 
     return mask;
   }
@@ -299,7 +299,6 @@ export class MagicWandService {
   */
   filterScribbles(scribbles: Set<number>, originalPixel: Array<number>, 
       imgData: ImageData, tolerance: number): Set<number> {
-    // TODO
     let result: Set<number> = new Set();
 
     for (let pixelIndex of scribbles) {

--- a/src/main/ngapp/accio/src/app/editor/magic-wand.service.ts
+++ b/src/main/ngapp/accio/src/app/editor/magic-wand.service.ts
@@ -175,4 +175,84 @@ export class MagicWandService {
 
     return invertedMask;
   }
+
+
+  /* Smarter flood fill tool */
+
+  scribbleFloodfill(imgData: ImageData, xCoord: number, yCoord: number,
+      tolerance: number, sribbles: Set<number>) {
+    /**Store a queue of coords for pixels that we need to visit in "visit".
+     * Store already-visited pixels in "visited" as index formatted numbers
+     * (as opposed to coord format; for Set funcs).
+     */
+    const visit: Array<Array<number>> = new Array();
+    const visited: Set<number> = new Set();
+    // Use a set for mask; mainly do iter and set operations on masks
+    const mask: Set<number> = new Set();
+    // Represent [R,G,B,A] attributes of initial pixel
+    const originalPixel: Array<number> =
+        this.dataArrayToRgba(imgData, xCoord, yCoord);
+
+    visit.push([xCoord, yCoord]);
+    // Convert [x,y] format coord to 1-D equivalent of imgData.data (DataArray)
+    const indexAsDataArray: number =
+        this.coordToDataArrayIndex(xCoord, yCoord, imgData.width);
+    visited.add(indexAsDataArray);
+
+    // Loop until no more adjacent pixels within tolerance level
+    while (visit.length !== 0) {
+      const coord: Array<number> = visit.pop();
+      // Unpack coord
+      const x: number = coord[0];
+      const y: number = coord[1];
+
+      // Operational part of while-loop
+      mask.add(this.coordToDataArrayIndex(x, y, imgData.width));
+
+      // Loop part of while-loop
+
+      // Get coords of adjacent pixels
+      const neighbors: Array<Array<number>> =
+          [[x - 1, y], [x + 1, y], [x, y - 1], [x, y + 1]];
+      // Add coords of adjacent pixels to the heap
+      for (const neighborPixel of neighbors) {
+        const x: number = neighborPixel[0];
+        const y: number = neighborPixel[1];
+        // Check if coord is in bounds and has not been visited first
+        if (!this.getIsValid(imgData.width, imgData.height, x, y, visited)) {
+          continue;
+        }
+        // Visit the pixel and check if it should be part of the mask
+        visited.add(this.coordToDataArrayIndex(x, y, imgData.width));
+        if (this.getIsScribbleMask(originalPixel, imgData, neighborPixel, tolerance)) {
+          visit.push(neighborPixel);
+        }
+      }
+    }  // end of while loop
+
+    return mask;
+  }
+
+  /**Judge current pixel's RGBA against original pixel's RGBA to
+   * see if it can still be part of the mask (using tolerance criteria).
+   */
+  getIsScribbleMask(originalPixel: Array<number>, imgData: ImageData,
+      pixelCoord: Array<number>, tolerance: number): boolean {
+    const curX: number = pixelCoord[0];
+    const curY: number = pixelCoord[1];
+
+    // Get array of attributes of current pixel
+    const curPixel: Array<number> = this.dataArrayToRgba(imgData, curX, curY);
+
+    // All attributes of the pixel (R,G,B, and A) must be within tolerance level
+    for (let i = 0; i < 4; i++) {
+      const upperTolerance: boolean = curPixel[i] > originalPixel[i] + tolerance;
+      const lowerTolerance: boolean = curPixel[i] < originalPixel[i] - tolerance;
+      if (upperTolerance || lowerTolerance) {
+        return false;
+      }
+    }
+
+    return true;
+  }
 }

--- a/src/main/ngapp/accio/src/app/editor/magic-wand.service.ts
+++ b/src/main/ngapp/accio/src/app/editor/magic-wand.service.ts
@@ -308,6 +308,9 @@ export class MagicWandService {
       imgData: ImageData, tolerance: number): Set<number> {
     let result: Set<number> = new Set();
 
+    // Work with tolerance logic in squared space for Euclidean distance.
+    const squaredTolerance = tolerance * tolerance;
+
     for (let pixelIndex of scribbles) {
       const pixelCoord: Array<number> = 
           this.pixelIndexToXYCoord(pixelIndex, imgData.width);
@@ -317,7 +320,7 @@ export class MagicWandService {
 
       const colorDifference = this.rgbEuclideanDist(originalPixel, curPixel);
 
-      if (colorDifference > tolerance / 2) {
+      if (colorDifference > squaredTolerance / 2) {
         result.add(pixelIndex);
       }
     }

--- a/src/main/ngapp/accio/src/app/editor/magic-wand.service.ts
+++ b/src/main/ngapp/accio/src/app/editor/magic-wand.service.ts
@@ -161,8 +161,15 @@ export class MagicWandService {
   }
 
 
-  /* Smarter flood fill tool */
-
+  /**Smarter flood fill tool:
+   *
+   * Compares the tolerance against a set of 
+   * reference pixels' colors as opposed to just an initial pixel's color.
+   * The user supplies a
+   * @param {Set<number>} scribbles set of pixels that is used to essentailly
+   * expand the range of the tolerance threshold as the floodfill
+   * percolates from the first-selected pixel. 
+   */
   scribbleFloodfill(imgData: ImageData, xCoord: number, yCoord: number,
       tolerance: number, scribbles: Set<number>): Set<number> {
     return this.doFloodfill(imgData, xCoord, yCoord, tolerance, scribbles);

--- a/src/main/ngapp/accio/src/app/editor/magic-wand.service.ts
+++ b/src/main/ngapp/accio/src/app/editor/magic-wand.service.ts
@@ -308,7 +308,7 @@ export class MagicWandService {
       imgData: ImageData, tolerance: number): Set<number> {
     let result: Set<number> = new Set();
 
-    // Work with tolerance logic in squared space for Euclidean distance.
+    // Work with tolerance logic in squared space for Euclidean distance. 
     const squaredTolerance = tolerance * tolerance;
 
     for (let pixelIndex of scribbles) {

--- a/src/main/ngapp/accio/src/app/editor/magic-wand.service.ts
+++ b/src/main/ngapp/accio/src/app/editor/magic-wand.service.ts
@@ -14,8 +14,11 @@ export class MagicWandService {
   floodfill(imgData: ImageData, xCoord: number, yCoord: number,
       tolerance: number): Set<number> {
     // An empty set is given for the scribbles parameter, so only a basic 
-    // floodfill is performed. 
-    return this.doFloodfill(imgData, xCoord, yCoord, tolerance, new Set<number>());
+    // floodfill is performed.
+    const scribbles = 
+        new Set<number>(
+        [this.coordToDataArrayIndex(xCoord, yCoord, imgData.width)]);
+    return this.doFloodfill(imgData, xCoord, yCoord, tolerance, scribbles);
   }
 
   /**Judges current pixel's RGB against original pixel's RGB to
@@ -270,72 +273,36 @@ export class MagicWandService {
         this.coordToDataArrayIndex(xCoord, yCoord, imgData.width);
     visited.add(indexAsDataArray);
 
-    // Performs a basic floodfill if the scribbles set is empty.
-    if (scribbles.size === 0) {
-      // Loops until no more adjacent pixels within tolerance level.
-      while (visit.length !== 0) {
-        const coord: Array<number> = visit.pop();
-        // Unpacks coord
-        const x: number = coord[0];
-        const y: number = coord[1];
+    // Loops until no more adjacent pixels within tolerance level.
+    while (visit.length !== 0) {
+      const coord: Array<number> = visit.pop();
+      // Unpacks coord.
+      const x: number = coord[0];
+      const y: number = coord[1];
 
-        // Operational part of while-loop.
-        mask.add(this.coordToDataArrayIndex(x, y, imgData.width));
+      // Operational part of while-loop.
+      mask.add(this.coordToDataArrayIndex(x, y, imgData.width));
 
-        // Loop part of while-loop.
+      // Loop part of while-loop.
 
-        // Gets coords of adjacent pixels.
-        const neighbors: Array<Array<number>> =
-            [[x - 1, y], [x + 1, y], [x, y - 1], [x, y + 1]];
-        // Adds coords of adjacent pixels to the heap.
-        for (const neighborPixel of neighbors) {
-          const x: number = neighborPixel[0];
-          const y: number = neighborPixel[1];
-          // Checks if coord is in bounds and has not been visited first.
-          if (!this.getIsValid(imgData.width, imgData.height, x, y, visited)) {
-            continue;
-          }
-          // Visits the pixel and checks if it should be part of the mask.
-          visited.add(this.coordToDataArrayIndex(x, y, imgData.width));
-          if (this.getIsMask(originalPixel, imgData, neighborPixel, tolerance)) {
-            visit.push(neighborPixel);
-          }
+      // Gets coords of adjacent pixels.
+      const neighbors: Array<Array<number>> =
+          [[x - 1, y], [x + 1, y], [x, y - 1], [x, y + 1]];
+      // Adds coords of adjacent pixels to the heap.
+      for (const neighborPixel of neighbors) {
+        const x: number = neighborPixel[0];
+        const y: number = neighborPixel[1];
+        // Checks if coord is in bounds and has not been visited first.
+        if (!this.getIsValid(imgData.width, imgData.height, x, y, visited)) {
+          continue;
         }
-      }  // End of while loop.
-    } else {
-      // Performs the scribble floodfill if the scribbles set is not empty.
-
-      // Loops until no more adjacent pixels within tolerance level.
-      while (visit.length !== 0) {
-        const coord: Array<number> = visit.pop();
-        // Unpacks coord.
-        const x: number = coord[0];
-        const y: number = coord[1];
-
-        // Operational part of while-loop.
-        mask.add(this.coordToDataArrayIndex(x, y, imgData.width));
-
-        // Loop part of while-loop.
-
-        // Gets coords of adjacent pixels.
-        const neighbors: Array<Array<number>> =
-            [[x - 1, y], [x + 1, y], [x, y - 1], [x, y + 1]];
-        // Adds coords of adjacent pixels to the heap.
-        for (const neighborPixel of neighbors) {
-          const x: number = neighborPixel[0];
-          const y: number = neighborPixel[1];
-          // Checks if coord is in bounds and has not been visited first.
-          if (!this.getIsValid(imgData.width, imgData.height, x, y, visited)) {
-            continue;
-          }
-          // Visits the pixel and check if it should be part of the mask.
-          visited.add(this.coordToDataArrayIndex(x, y, imgData.width));
-          if (this.getIsScribbleMask(scribbles, imgData, neighborPixel, tolerance)) {
-            visit.push(neighborPixel);
-          }
+        // Visits the pixel and check if it should be part of the mask.
+        visited.add(this.coordToDataArrayIndex(x, y, imgData.width));
+        if (this.getIsScribbleMask(scribbles, imgData, neighborPixel, tolerance)) {
+          visit.push(neighborPixel);
         }
-      }  // End of while loop.
-    }
+      }
+    }  // End of while loop.
     
     return mask;
   }

--- a/src/main/ngapp/accio/src/app/editor/magic-wand.service.ts
+++ b/src/main/ngapp/accio/src/app/editor/magic-wand.service.ts
@@ -261,7 +261,7 @@ export class MagicWandService {
     return mask;
   }
 
-  /**Judges current pixel's RGB against original pixel's RGB to
+  /**Judges current pixel's RGB against a set of reference pixels' RGBs to
    * see if it can still be part of the mask (using tolerance criteria).
    */
   getIsScribbleMask(scribbles: Set<number>, imgData: ImageData,

--- a/src/main/ngapp/accio/src/app/editor/magic-wand.service.ts
+++ b/src/main/ngapp/accio/src/app/editor/magic-wand.service.ts
@@ -22,7 +22,7 @@ export class MagicWandService {
     const mask: Set<number> = new Set();
     // Represents [R,G,B] attributes of initial pixel.
     const originalPixel: Array<number> =
-        this.dataArrayToRgba(imgData, xCoord, yCoord);
+        this.dataArrayToRgb(imgData, xCoord, yCoord);
 
     visit.push([xCoord, yCoord]);
     // Converts [x,y] format coord to 1-D equivalent of
@@ -74,7 +74,7 @@ export class MagicWandService {
     const curY: number = pixelCoord[1];
 
     // Gets [R, G, B] of current pixel.
-    const curPixel: Array<number> = this.dataArrayToRgba(imgData, curX, curY);
+    const curPixel: Array<number> = this.dataArrayToRgb(imgData, curX, curY);
 
     const colorDifference = this.rgbEuclideanDist(originalPixel, curPixel);
 
@@ -141,7 +141,7 @@ export class MagicWandService {
    * @param {number} yCoord based off of the original image supplied by
    * @param {ImageData} imgData
    */
-  dataArrayToRgba(imgData: ImageData, xCoord: number, yCoord: number):
+  dataArrayToRgb(imgData: ImageData, xCoord: number, yCoord: number):
       Array<number> {
     // Unpacks imgData for readability.
     const data: Uint8ClampedArray = imgData.data;
@@ -216,7 +216,7 @@ export class MagicWandService {
     const mask: Set<number> = new Set();
     // Represents [R,G,B] attributes of initial pixel.
     const originalPixel: Array<number> =
-        this.dataArrayToRgba(imgData, xCoord, yCoord);
+        this.dataArrayToRgb(imgData, xCoord, yCoord);
 
     visit.push([xCoord, yCoord]);
     // Converts [x,y] format to 1-D equivalent of imgData.data (DataArray).
@@ -270,14 +270,14 @@ export class MagicWandService {
     const curY: number = pixelCoord[1];
 
     // Gets array of color attributes of current pixel.
-    const curPixel: Array<number> = this.dataArrayToRgba(imgData, curX, curY);
+    const curPixel: Array<number> = this.dataArrayToRgb(imgData, curX, curY);
 
     for (let pixelIndex of scribbles) {
       const refPixelCoord: Array<number> = 
           this.pixelIndexToXYCoord(pixelIndex, imgData.width);
       const x = refPixelCoord[0];
       const y = refPixelCoord[1];
-      const refPixel = this.dataArrayToRgba(imgData, x, y);
+      const refPixel = this.dataArrayToRgb(imgData, x, y);
 
       const colorDifference = this.rgbEuclideanDist(refPixel, curPixel);
 
@@ -307,7 +307,7 @@ export class MagicWandService {
           this.pixelIndexToXYCoord(pixelIndex, imgData.width);
       const x = pixelCoord[0];
       const y = pixelCoord[1];
-      const curPixel = this.dataArrayToRgba(imgData, x, y);
+      const curPixel = this.dataArrayToRgb(imgData, x, y);
 
       const colorDifference = this.rgbEuclideanDist(originalPixel, curPixel);
 

--- a/src/main/ngapp/accio/src/app/editor/magic-wand.service.ts
+++ b/src/main/ngapp/accio/src/app/editor/magic-wand.service.ts
@@ -229,7 +229,7 @@ export class MagicWandService {
 
       const colorDifference = this.rgbEuclideanDist(originalPixel, curPixel);
 
-      if (colorDifference > squaredTolerance / 2) {
+      if (colorDifference !== 0 && colorDifference > squaredTolerance / 2) {
         result.add(pixelIndex);
       }
     }

--- a/src/main/ngapp/accio/src/app/editor/magic-wand.service.ts
+++ b/src/main/ngapp/accio/src/app/editor/magic-wand.service.ts
@@ -7,65 +7,65 @@ import { SetOperator } from './set-operator';
 })
 export class MagicWandService {
   /**4-Way floodfill (left, right, up, down):
-   * Return set of coordinates(formatted as a 1-D array).
+   * @returns {Set<number>} set of coordinates(formatted as a 1-D array).
    * Coordinates correspond to pixels considered part of the mask.
    */
   /* tslint:disable */
   floodfill(imgData: ImageData, xCoord: number, yCoord: number,
       tolerance: number): Set<number> {
-    /**Store a queue of coords for pixels that we need to visit in "visit".
-     * Store already-visited pixels in "visited" as index formatted numbers
-     * (as opposed to coord format; for Set funcs).
-     */
+    // Stores a queue of coords for pixels that we need to visit in "visit".
     const visit: Array<Array<number>> = new Array();
+    // Stores already-visited pixels in "visited" as index formatted numbers
+    // (as opposed to coord format; for Set funcs).
     const visited: Set<number> = new Set();
-    // Use a set for mask; mainly do iter and set operations on masks
+    // Uses a set for mask; mainly do iter and set operations on masks...
     const mask: Set<number> = new Set();
-    // Represent [R,G,B,A] attributes of initial pixel
+    // Represents [R,G,B] attributes of initial pixel.
     const originalPixel: Array<number> =
         this.dataArrayToRgba(imgData, xCoord, yCoord);
 
     visit.push([xCoord, yCoord]);
-    // Convert [x,y] format coord to 1-D equivalent of imgData.data (DataArray)
+    // Converts [x,y] format coord to 1-D equivalent of
+    // imgData.data (DataArray).
     const indexAsDataArray: number =
         this.coordToDataArrayIndex(xCoord, yCoord, imgData.width);
     visited.add(indexAsDataArray);
 
-    // Loop until no more adjacent pixels within tolerance level
+    // Loops until no more adjacent pixels within tolerance level.
     while (visit.length !== 0) {
       const coord: Array<number> = visit.pop();
-      // Unpack coord
+      // Unpacks coord
       const x: number = coord[0];
       const y: number = coord[1];
 
-      // Operational part of while-loop
+      // Operational part of while-loop...
       mask.add(this.coordToDataArrayIndex(x, y, imgData.width));
 
-      // Loop part of while-loop
+      // Loop part of while-loop...
 
-      // Get coords of adjacent pixels
+      // Gets coords of adjacent pixels.
       const neighbors: Array<Array<number>> =
           [[x - 1, y], [x + 1, y], [x, y - 1], [x, y + 1]];
-      // Add coords of adjacent pixels to the heap
+      // Adds coords of adjacent pixels to the heap.
       for (const neighborPixel of neighbors) {
         const x: number = neighborPixel[0];
         const y: number = neighborPixel[1];
-        // Check if coord is in bounds and has not been visited first
+        // Checks if coord is in bounds and has not been visited first.
         if (!this.getIsValid(imgData.width, imgData.height, x, y, visited)) {
           continue;
         }
-        // Visit the pixel and check if it should be part of the mask
+        // Visits the pixel and checks if it should be part of the mask.
         visited.add(this.coordToDataArrayIndex(x, y, imgData.width));
         if (this.getIsMask(originalPixel, imgData, neighborPixel, tolerance)) {
           visit.push(neighborPixel);
         }
       }
-    }  // end of while loop
+    }  // End of while loop...
 
     return mask;
   }
 
-  /**Judge current pixel's RGBA against original pixel's RGBA to
+  /**Judges current pixel's RGB against original pixel's RGB to
    * see if it can still be part of the mask (using tolerance criteria).
    */
   getIsMask(originalPixel: Array<number>, imgData: ImageData,
@@ -73,11 +73,11 @@ export class MagicWandService {
     const curX: number = pixelCoord[0];
     const curY: number = pixelCoord[1];
 
-    // Get array of attributes of current pixel
+    // Gets array of the color attributes of current pixel.
     const curPixel: Array<number> = this.dataArrayToRgba(imgData, curX, curY);
 
-    // All attributes of the pixel (R,G,B, and A) must be within tolerance level
-    for (let i = 0; i < 4; i++) {
+    // Color attributes of pixel (R,G, and B) must be within tolerance level.
+    for (let i = 0; i < 3; i++) {
       const upperTolerance: boolean = curPixel[i] > originalPixel[i] + tolerance;
       const lowerTolerance: boolean = curPixel[i] < originalPixel[i] - tolerance;
       if (upperTolerance || lowerTolerance) {
@@ -88,14 +88,38 @@ export class MagicWandService {
     return true;
   }
 
-  // Check if @pixelCoord is in bounds and makes sure it's not a repeat coord
+  /**@returns {number} the straight line distance between the two colors
+   * @param {Array<number> [R, G, B]} basisColor and 
+   * @param {Array<number> [R, G, B]} secondColor
+   */
+  RgbEuclideanDist(basisColor: Array<number>, secondColor: Array<number>)
+      : number {
+    if (basisColor.length != secondColor.length) {
+      throw new Error(
+          'basisColor and secondColor must be same lengthed arrays...');
+    }
+    if (basisColor.length != 3) {
+      throw new Error(
+          'Arguments must be an array of [R, G, B] (length == 3)...');
+    }
+
+    let distance = 0;
+
+    for (let i = 0; i < basisColor.length; i++) {
+      distance += Math.pow((basisColor[i] - secondColor[i]), 2);
+    }
+
+    return Math.sqrt(distance);
+  } 
+
+  // Checks if @pixelCoord is in bounds and makes sure it's not a repeat coord.
   getIsValid(imgWidth: number, imgHeight: number, curX: number, curY: number,
       visited: Set<number>): boolean {
     return this.isInBounds(imgWidth, imgHeight, curX, curY) &&
         this.notVisited(imgWidth, curX, curY, visited);
   }
 
-  // Check bounds of indexing for img dimensions
+  // Checks bounds of indexing for img dimensions.
   isInBounds(imgWidth: number, imgHeight: number, curX: number, curY: number):
       boolean {
     let yInBounds: boolean = curY >= 0 && curY < imgHeight;
@@ -104,10 +128,10 @@ export class MagicWandService {
     return yInBounds && xInBounds;
   }
 
-  // Checks if pixel has been visited already
+  // Checks if pixel has been visited already.
   notVisited(imgWidth: number, curX: number, curY: number,
       visited: Set<number>): boolean {
-    // Do not push repeat coords to heap
+    // Do not push repeating coords to heap...
     const index: number =
         this.coordToDataArrayIndex(curX, curY, imgWidth);
 
@@ -115,29 +139,32 @@ export class MagicWandService {
   }
 
 
-  // Return pixel attributes of @imgData at [@xCoord, @yCoord] as [R, G, B, A]
+  /**@returns {Array<number> [R, G, B]} color attribute of the pixel at 
+   * @param {number} xCoord and 
+   * @param {number} yCoord based off of the original image supplied by
+   * @param {ImageData} imgData
+   */
   dataArrayToRgba(imgData: ImageData, xCoord: number, yCoord: number):
       Array<number> {
-    // Unpack imgData for readability
+    // Unpacks imgData for readability.
     const data: Uint8ClampedArray = imgData.data;
     const imgWidth: number = imgData.width;
 
-    // Pixel attributes in imgData are organized adjacently in a 1-D array
+    // Pixel attributes in imgData are organized adjacently in a 1-D array.
     const pixelIndex: number =
         this.coordToDataArrayIndex(xCoord, yCoord, imgWidth);
     const red: number = data[pixelIndex];
     const green: number = data[pixelIndex + 1];
     const blue: number = data[pixelIndex + 2];
-    const alpha: number = data[pixelIndex + 3];
-    // Store original pixel's attributes
-    return [red, green, blue, alpha];
+    
+    return [red, green, blue];
   }
 
-  // Convert coord [@x, @y] (2-D) to indexing style of DataArray (1-D)
-  /**Returns index of start of pixel at @x, @y
+  // Converts coord [@x, @y] (2-D) to indexing style of DataArray (1-D)
+  /**@returns {number} index of the start of the pixel at
+   * @param {number} x and 
+   * @param {number} y 
    * (which represents the red attribute of that pixel)
-   * Important: Returns array of number representing indices.
-   * First element contains value of index for attribute: red and so on
    */
   coordToDataArrayIndex(x: number, y: number, width: number): number {
     return (x + (y * width)) * 4;
@@ -148,7 +175,8 @@ export class MagicWandService {
 
   /**@returns {Set<number>} mask that excludes the
    * @param {Set<number>} mistake from original
-   * @param {Set<number>} mask*/
+   * @param {Set<number>} mask
+   */
   erase(mask: Set<number>, mistake: Set<number>): Set<number> {
     return SetOperator.difference(mask, mistake);
   }
@@ -157,7 +185,8 @@ export class MagicWandService {
    * @param {Set<number>} originalMask .
    * Relative container that encompasses @originalMask is based on
    * @param {number} height and 
-   * @param {number} width */
+   * @param {number} width 
+   */
   invert(originalMask: Set<number>, width: number, height: number)
       : Set<number> {
     let invertedMask: Set<number> = new Set();
@@ -180,72 +209,74 @@ export class MagicWandService {
   /* Smarter flood fill tool */
 
   scribbleFloodfill(imgData: ImageData, xCoord: number, yCoord: number,
-      tolerance: number, sribbles: Set<number>) {
-    /**Store a queue of coords for pixels that we need to visit in "visit".
-     * Store already-visited pixels in "visited" as index formatted numbers
-     * (as opposed to coord format; for Set funcs).
-     */
+      tolerance: number, scribbles: Set<number>): Set<number> {
+    // Stores a queue of coords for pixels that we need to visit in "visit".
     const visit: Array<Array<number>> = new Array();
+    // Stores already-visited pixels in "visited" as index formatted numbers
+    // (as opposed to coord format; for Set funcs).
     const visited: Set<number> = new Set();
-    // Use a set for mask; mainly do iter and set operations on masks
+    // Uses a set for mask; mainly do iter and set operations on masks.
     const mask: Set<number> = new Set();
-    // Represent [R,G,B,A] attributes of initial pixel
+    // Represents [R,G,B] attributes of initial pixel.
     const originalPixel: Array<number> =
         this.dataArrayToRgba(imgData, xCoord, yCoord);
 
     visit.push([xCoord, yCoord]);
-    // Convert [x,y] format coord to 1-D equivalent of imgData.data (DataArray)
+    // Converts [x,y] format to 1-D equivalent of imgData.data (DataArray).
     const indexAsDataArray: number =
         this.coordToDataArrayIndex(xCoord, yCoord, imgData.width);
     visited.add(indexAsDataArray);
 
-    // Loop until no more adjacent pixels within tolerance level
+    // Filters scribbles by removing unnecessary pixels
+    scribbles = filterScribbles(scribbles, tolerance);
+
+    // Loops until no more adjacent pixels within tolerance level.
     while (visit.length !== 0) {
       const coord: Array<number> = visit.pop();
-      // Unpack coord
+      // Unpacks coord.
       const x: number = coord[0];
       const y: number = coord[1];
 
-      // Operational part of while-loop
+      // Operational part of while-loop...
       mask.add(this.coordToDataArrayIndex(x, y, imgData.width));
 
-      // Loop part of while-loop
+      // Loop part of while-loop...
 
-      // Get coords of adjacent pixels
+      // Gets coords of adjacent pixels.
       const neighbors: Array<Array<number>> =
           [[x - 1, y], [x + 1, y], [x, y - 1], [x, y + 1]];
-      // Add coords of adjacent pixels to the heap
+      // Adds coords of adjacent pixels to the heap.
       for (const neighborPixel of neighbors) {
         const x: number = neighborPixel[0];
         const y: number = neighborPixel[1];
-        // Check if coord is in bounds and has not been visited first
+        // Checks if coord is in bounds and has not been visited first.
         if (!this.getIsValid(imgData.width, imgData.height, x, y, visited)) {
           continue;
         }
-        // Visit the pixel and check if it should be part of the mask
+        // Visits the pixel and check if it should be part of the mask.
         visited.add(this.coordToDataArrayIndex(x, y, imgData.width));
         if (this.getIsScribbleMask(originalPixel, imgData, neighborPixel, tolerance)) {
           visit.push(neighborPixel);
         }
       }
-    }  // end of while loop
+    }  // End of while loop...
 
     return mask;
   }
 
-  /**Judge current pixel's RGBA against original pixel's RGBA to
+  /**Judges current pixel's RGB against original pixel's RGB to
    * see if it can still be part of the mask (using tolerance criteria).
    */
   getIsScribbleMask(originalPixel: Array<number>, imgData: ImageData,
-      pixelCoord: Array<number>, tolerance: number): boolean {
+      pixelCoord: Array<number>, tolerance: number, scribbles: Set<number>): boolean {
     const curX: number = pixelCoord[0];
     const curY: number = pixelCoord[1];
 
-    // Get array of attributes of current pixel
+    // Gets array of color attributes of current pixel.
     const curPixel: Array<number> = this.dataArrayToRgba(imgData, curX, curY);
 
-    // All attributes of the pixel (R,G,B, and A) must be within tolerance level
-    for (let i = 0; i < 4; i++) {
+    // Color attributes of pixel (R,G, and B) must be within tolerance level.
+    for (let i = 0; i < 3; i++) {
       const upperTolerance: boolean = curPixel[i] > originalPixel[i] + tolerance;
       const lowerTolerance: boolean = curPixel[i] < originalPixel[i] - tolerance;
       if (upperTolerance || lowerTolerance) {
@@ -254,5 +285,18 @@ export class MagicWandService {
     }
 
     return true;
+  }
+
+  filterScribbles(scribbles: Set<number>, tolerance: number): Set<number> {
+    // TODO
+    let result: Set<number> = new Set();
+    for (let pixelCoord of scribbles) {
+      pixelColor = RgbEuclideanDist();
+      if (/* filter condition */) {
+        result.add(pixelCoord);
+      }
+    }
+
+    return result;
   }
 }

--- a/src/main/ngapp/accio/src/app/editor/magic-wand.service.ts
+++ b/src/main/ngapp/accio/src/app/editor/magic-wand.service.ts
@@ -273,13 +273,13 @@ export class MagicWandService {
     const curPixel: Array<number> = this.dataArrayToRgba(imgData, curX, curY);
 
     for (let pixelIndex of scribbles) {
-      const pixelCoord: Array<number> = 
+      const refPixelCoord: Array<number> = 
           this.pixelIndexToXYCoord(pixelIndex, imgData.width);
-      const x = pixelCoord[0];
-      const y = pixelCoord[1];
-      const curPixel = this.dataArrayToRgba(imgData, x, y);
+      const x = refPixelCoord[0];
+      const y = refPixelCoord[1];
+      const refPixel = this.dataArrayToRgba(imgData, x, y);
 
-      const colorDifference = this.rgbEuclideanDist(originalPixel, curPixel);
+      const colorDifference = this.rgbEuclideanDist(refPixel, curPixel);
 
       // If the curPixel is tolerable for at least 1 of the reference pixels,
       // then the curPixel will be part of the mask.

--- a/src/main/ngapp/accio/src/app/editor/magic-wand.service.ts
+++ b/src/main/ngapp/accio/src/app/editor/magic-wand.service.ts
@@ -243,7 +243,7 @@ export class MagicWandService {
    * pixelIndex belongs to.
    */
   pixelIndexToXYCoord(pixelIndex: number, width: number): Array<number> {
-    return [((pixelIndex / 4) % width), ((pixelIndex / 4) / width)];
+    return [((pixelIndex / 4) % width), (Math.floor((pixelIndex / 4) / width))];
   }
 
   /**Does the general floodfill algorithm, and switches to 


### PR DESCRIPTION
- Change tolerance logic to compare tolerance value based on euclidean distance instead of comparing each individual R, G, 
  and B value.
- Update appropriate comments
- Implement an initial scribbleFloodfill() (waiting for brush UI to be merged to master so that scribbleFloodfill() can be better 
  tested and optimized).
    - Add helper method pixelIndexToXYCoord()
        - Converts pixel index {number} into an [x, y] coodinate {Array<number> [x, y]}
    - Implement helper method getIsScribbleMask()
        - Adds the pixel to the mask as long as it satisfies the color tolerance for at least 1 pixel in the set of reference pixels.