### PR TITLE
Implement "preview" feature algo

### DIFF
--- a/src/main/ngapp/accio/src/app/editor/magic-wand.service.spec.ts
+++ b/src/main/ngapp/accio/src/app/editor/magic-wand.service.spec.ts
@@ -1,154 +1,220 @@
 import { TestBed } from '@angular/core/testing';
-
-import { MagicWandService } from './magic-wand.service';
-
+import { MagicWandService, MasterMask } from './magic-wand.service';
 
 /* tslint:disable */
 describe('MagicWandService', () => {
- let service: MagicWandService;
+  let service: MagicWandService;
 
- beforeEach(() => {
-   TestBed.configureTestingModule({});
-   service = TestBed.inject(MagicWandService);
- });
+  const RED: Color = {red: 4, green: 0, blue: 0};
+  const BLUE: Color = {red: 0, green: 0, blue: 3};
+  const GREEN: Color = {red: 0, green: 2, blue: 0};
 
- it('should be created', () => {
-   expect(service).toBeTruthy();
- });
- it('Test method: coordToDataArrayIndex()', () => {
-   // Should convert [x][y] to 1-D indexing
-   expect(service.coordToDataArrayIndex(
-       0, 0, 100)).toEqual(0);
-   expect(service.coordToDataArrayIndex(
-       1, 5, 100)).toEqual(2004);
- });
- it('Test method: dataArrayToRgba()', () => {
-   // Should access RGBA values of img given a coord
-   const imgData: ImageData = new ImageData(11, 4);
-   imgData.data[56] = 120;  // Red
-   imgData.data[56 + 1] = 111;  // Green
-   imgData.data[56 + 2] = 117;  // Blue
-   expect(service.dataArrayToRgb(
-       imgData, 3, 1)).toEqual({red: 120, green: 111, blue: 117});
- });
- it('Test method: isInBounds() >> top left OutOfRange', () => {
-   // Should return false if inputted pixel's coord is out of range of the img
-   expect(service.isInBounds(
-       11, 4, -1, 1)).toEqual(false);
- });
- it('Test method: isInBounds() >> top right OutOfRange', () => {
-   expect(service.isInBounds(
-       11, 4, 11, 1)).toEqual(false);
- });
- it('Test method: isInBounds() >> bot left OutOfRange', () => {
-   expect(service.isInBounds(
-       11, 4, 4, -1)).toEqual(false);
- });
- it('Test method: isInBounds() >> bot right OutOfRange', () => {
-   expect(service.isInBounds(
-       11, 4, 4, 4)).toEqual(false);
- });
- it('Test method: isInBounds() >> in range', () => {
-   // Should return true if inputted pixel's coords in in range of img
-   expect(service.isInBounds(
-       11, 4, 4, 2)).toEqual(true);
- });
- it('Test method: getIsValid() >> not valid', () => {
-   // Should return false if isInBounds() but already visited
-   expect(service.getIsValid(11, 4, 5, 0, new Set([20]))).toEqual(false);
- });
- it('Test method: getIsValid() >> valid', () => {
-   // Should return true if isInBounds() and not yet visited
-   const visited: Set<number> = new Set([24]);
-   expect(service.getIsValid(11, 4, 5, 0, visited)).toEqual(true);
- });
- it('Test method: floodfill() >> no adjacent pixels in mask', () => {
-   // Should only return index of pixel that was initially clicked
-   const imgData: ImageData = makeTestImage(
-       11, 4, [255, 255, 255, 255], new Set<number>(
-       [8, 24, 28, 36, 48, 56, 64, 76, 96, 100, 112, 116, 152]));
-   expect(service.floodfill(imgData, 2, 1, 1)).toEqual(new Set<number>([52]));
- });
- it('Test method: floodfill() >> small mask, touches border', () => {
-   // Should return a mask covering the bottom right corner of the img
-   const imgData: ImageData = makeTestImage(
-       11, 4, [255, 255, 255, 255], new Set<number>(
-       [8, 24, 28, 36, 48, 56, 64, 76, 96, 100, 112, 116, 152]));
-   expect(service.floodfill(imgData, 8, 2, 1)).toEqual(new Set<number>(
-       [40, 80, 84, 120, 124, 128, 156, 160, 164, 168, 172]));
- });
- it('Test method: floodfill() >> small mask in middle of img', () => {
-   // Should return a mask covering the bottom right corner of the img
-   const imgData: ImageData = makeTestImage(
-       11, 4, [255, 255, 255, 255], new Set<number>(
-       [8, 24, 28, 36, 48, 56, 64, 76, 96, 100, 112, 116, 152]));
-   expect(service.floodfill(imgData, 6, 1, 1)).toEqual(new Set<number>(
-       [68, 72]));
- });
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(MagicWandService);
+  });
 
- it('Test method: erase()', () => {
-   // Should return a mask with pixels from the input set being excluded
-   const originalMask: Set<number> = new Set([0, 8, 12, 40, 44]);
-   const mistake: Set<number> = new Set([12, 40]);
-   const expected: Set<number> = new Set([0, 8, 44]);
-   expect(service.erase(originalMask, mistake)).toEqual(expected);
- });
- it('Test method: invert()', () => {
-   // Should return a mask with pixels from the input set being excluded
-   const originalMask: Set<number> = new Set([0, 8, 12, 40, 44]);
-   const expected: Set<number> = new Set([4, 16, 20, 24, 28, 32, 36]);
-   expect(service.invert(originalMask, 4, 3)).toEqual(expected);
- });
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+  it('Test method: coordToDataArrayIndex()', () => {
+    // Should convert [x][y] to 1-D indexing
+    expect(service.coordToDataArrayIndex(
+        0, 0, 100)).toEqual(0);
+    expect(service.coordToDataArrayIndex(
+        1, 5, 100)).toEqual(2004);
+  });
+  it('Test method: dataArrayToRgba()', () => {
+    // Should access RGBA values of img given a coord
+    const imgData: ImageData = new ImageData(11, 4);
+    imgData.data[56] = 120;  // Red
+    imgData.data[56 + 1] = 111;  // Green
+    imgData.data[56 + 2] = 117;  // Blue
+    expect(service.dataArrayToRgb(
+        imgData, 3, 1)).toEqual({red: 120, green: 111, blue: 117});
+  });
+  it('Test method: isInBounds() >> top left OutOfRange', () => {
+    // Should return false if inputted pixel's coord is out of range of the img
+    expect(service.isInBounds(
+        11, 4, -1, 1)).toEqual(false);
+  });
+  it('Test method: isInBounds() >> top right OutOfRange', () => {
+    expect(service.isInBounds(
+        11, 4, 11, 1)).toEqual(false);
+  });
+  it('Test method: isInBounds() >> bot left OutOfRange', () => {
+    expect(service.isInBounds(
+        11, 4, 4, -1)).toEqual(false);
+  });
+  it('Test method: isInBounds() >> bot right OutOfRange', () => {
+    expect(service.isInBounds(
+        11, 4, 4, 4)).toEqual(false);
+  });
+  it('Test method: isInBounds() >> in range', () => {
+    // Should return true if inputted pixel's coords in in range of img
+    expect(service.isInBounds(
+        11, 4, 4, 2)).toEqual(true);
+  });
+  it('Test method: getIsValid() >> not valid', () => {
+    // Should return false if isInBounds() but already visited
+    expect(service.getIsValid(11, 4, 5, 0, new Set([20]))).toEqual(false);
+  });
+  it('Test method: getIsValid() >> valid', () => {
+    // Should return true if isInBounds() and not yet visited
+    const visited: Set<number> = new Set([24]);
+    expect(service.getIsValid(11, 4, 5, 0, visited)).toEqual(true);
+  });
+  it('Test method: floodfill() >> no adjacent pixels in mask', () => {
+    // Should only return index of pixel that was initially clicked
+    const imgData: ImageData = makeTestImage(
+        11, 4, [255, 255, 255, 255], new Set<number>(
+        [8, 24, 28, 36, 48, 56, 64, 76, 96, 100, 112, 116, 152]));
+    expect(service.floodfill(imgData, 2, 1, 1)).toEqual(new Set<number>([52]));
+  });
+  it('Test method: floodfill() >> small mask, touches border', () => {
+    // Should return a mask covering the bottom right corner of the img
+    const imgData: ImageData = makeTestImage(
+        11, 4, [255, 255, 255, 255], new Set<number>(
+        [8, 24, 28, 36, 48, 56, 64, 76, 96, 100, 112, 116, 152]));
+    expect(service.floodfill(imgData, 8, 2, 1)).toEqual(new Set<number>(
+        [40, 80, 84, 120, 124, 128, 156, 160, 164, 168, 172]));
+  });
+  it('Test method: floodfill() >> small mask in middle of img', () => {
+    // Should return a mask covering the bottom right corner of the img
+    const imgData: ImageData = makeTestImage(
+        11, 4, [255, 255, 255, 255], new Set<number>(
+        [8, 24, 28, 36, 48, 56, 64, 76, 96, 100, 112, 116, 152]));
+    expect(service.floodfill(imgData, 6, 1, 1)).toEqual(new Set<number>(
+        [68, 72]));
+  });
 
- it('Test method: rgbEuclideanDist()', () => {
-   // Should return the straight line distance between two pixels' colors
-   const colorA = {red: 2, green: 4, blue: 1};
-   const colorB = {red: 7, green: 2, blue: 2};
-   // Euclidean distance, kept in squared space
-   expect(service.rgbEuclideanDist(colorA, colorB)).toEqual(30);
- });
+  it('Test method: erase()', () => {
+    // Should return a mask with pixels from the input set being excluded
+    const originalMask: Set<number> = new Set([0, 8, 12, 40, 44]);
+    const mistake: Set<number> = new Set([12, 40]);
+    const expected: Set<number> = new Set([0, 8, 44]);
+    expect(service.erase(originalMask, mistake)).toEqual(expected);
+  });
+  it('Test method: invert()', () => {
+    // Should return a mask with pixels from the input set being excluded
+    const originalMask: Set<number> = new Set([0, 8, 12, 40, 44]);
+    const expected: Set<number> = new Set([4, 16, 20, 24, 28, 32, 36]);
+    expect(service.invert(originalMask, 4, 3)).toEqual(expected);
+  });
 
- it('Test method: pixelIndexToXYCoord()', () => {
-   expect(service.pixelIndexToXYCoord(8, 4)).toEqual([2, 0]);
-   expect(service.pixelIndexToXYCoord(148, 11)).toEqual([4, 3]);
- });
- it('Test method: scribbleFloodfill()', () => {
-   const imgData: ImageData = makeTestImage(
-       4, 4, [255, 255, 255, 255], new Set<number>(
-       [8, 12, 16]));
-   for (let i of [20, 24, 28, 32]) {
-     imgData.data[i] = 120;
-     imgData.data[i + 1] = 120;
-     imgData.data[i + 2] = 120;
-     imgData.data[i + 3] = 120;
-   }
+  it('Test method: rgbEuclideanDist()', () => {
+    // Should return the straight line distance between two pixels' colors
+    const colorA = {red: 2, green: 4, blue: 1};
+    const colorB = {red: 7, green: 2, blue: 2};
+    // Euclidean distance, kept in squared space
+    expect(service.rgbEuclideanDist(colorA, colorB)).toEqual(30);
+  });
 
-   expect(service.scribbleFloodfill(
-       imgData, 1, 0, 5, new Set<number>([4, 8]))).toEqual(
-       new Set<number>([0, 4, 8, 12, 16]));
- });
- it('Test method: scribblesToColors()', () => {
-   const imgData: ImageData = makeTestImage(
-       3, 3, [5, 6, 7, 255], new Set<number>([4]));
-   expect(service.scribblesToColors(
-       new Set<number>([4]), imgData)).toEqual(
-       [{red: 5, green: 6, blue: 7}]);
- });
- it('Test Error: scribblesToColors() OutOfRange', () => {
-   const imgData = new ImageData(3, 3);
-   expect(() => {service.scribblesToColors(new Set<number>([-1]), imgData)}).
-       toThrowError(
-       'Pixel index from scribbles set is out of range...');
-   expect(() => {service.scribblesToColors(new Set<number>([36]), imgData)}).
-       toThrowError(
-       'Pixel index from scribbles set is out of range...');
- });
- it('Test Error: scribblesToColors() Bad indexing', () => {
-   const imgData = new ImageData(3, 3);
-   expect(() =>  {service.scribblesToColors(new Set<number>([3]), imgData)}).
-     toThrowError(
-     'Pixel index not pointing to the start of a new pixel...');
- });
+  it('Test method: pixelIndexToXYCoord()', () => {
+    expect(service.pixelIndexToXYCoord(8, 4)).toEqual([2, 0]);
+    expect(service.pixelIndexToXYCoord(148, 11)).toEqual([4, 3]);
+  });
+  it('Test method: scribbleFloodfill()', () => {
+    const imgData: ImageData = makeTestImage(
+        4, 4, [255, 255, 255, 255], new Set<number>(
+        [8, 12, 16]));
+    for (let i of [20, 24, 28, 32]) {
+      imgData.data[i] = 120;
+      imgData.data[i + 1] = 120;
+      imgData.data[i + 2] = 120;
+      imgData.data[i + 3] = 120;
+    }
+
+    expect(service.scribbleFloodfill(
+        imgData, 1, 0, 5, new Set<number>([4, 8]))).toEqual(
+        new Set<number>([0, 4, 8, 12, 16]));
+  });
+  it('Test method: scribblesToColors()', () => {
+    const imgData: ImageData = makeTestImage(
+        3, 3, [5, 6, 7, 255], new Set<number>([4]));
+    expect(service.scribblesToColors(
+        new Set<number>([4]), imgData)).toEqual(
+        [{red: 5, green: 6, blue: 7}]);
+  });
+  it('Test Error: scribblesToColors() OutOfRange', () => {
+    const imgData = new ImageData(3, 3);
+    expect(() => {service.scribblesToColors(new Set<number>([-1]), imgData)}).
+        toThrowError(
+        'Pixel index from scribbles set is out of range...');
+    expect(() => {service.scribblesToColors(new Set<number>([36]), imgData)}).
+        toThrowError(
+        'Pixel index from scribbles set is out of range...');
+  });
+  it('Test Error: scribblesToColors() Bad indexing', () => {
+    const imgData = new ImageData(3, 3);
+    expect(() =>  {service.scribblesToColors(new Set<number>([3]), imgData)}).
+      toThrowError(
+      'Pixel index not pointing to the start of a new pixel...');
+  });
+  it('Test Method: getAllFloodfillls()', () => {
+  let imgData: ImageData = makeImageExampleA();
+
+  const masterMask: MasterMask = service.getAllFloodfills(imgData, 2, 2, 420);
+
+  expect(masterMask.masksByTolerance[0]).toEqual(
+      new Set<number>([24, 28, 32, 52, 56, 60]));
+  expect(masterMask.masksByTolerance[2]).toEqual(
+      new Set<number>([12, 36, 84, 88]));
+  expect(masterMask.masksByTolerance[3]).toEqual(
+      new Set<number>([4, 8, 76, 108, 112]));
+  expect(masterMask.masksByTolerance[4]).toEqual(
+      new Set<number>([0, 16, 48, 64, 80, 92, 104, 116]));
+  });
+  it('Test Method: maskAtTolerance()', () => {
+  let imgData: ImageData = makeImageExampleA();
+
+  const masterMask: MasterMask = service.getAllFloodfills(imgData, 2, 2, 420);
+
+  expect(masterMask.maskAtTolerance(0)).toEqual(
+      new Set<number>([24, 28, 32, 52, 56, 60]));
+  expect(masterMask.maskAtTolerance(1)).toEqual(
+      new Set<number>([24, 28, 32, 52, 56, 60]));
+  expect(masterMask.maskAtTolerance(2)).toEqual(
+      new Set<number>([24, 28, 32, 52, 56, 60, 12, 36, 84, 88]));
+  expect(masterMask.maskAtTolerance(3)).toEqual(
+      new Set<number>([24, 28, 32, 52, 56, 60, 12, 36, 84, 88, 4, 8,
+      76, 108, 112]));
+  expect(masterMask.maskAtTolerance(2)).toEqual(
+      new Set<number>([24, 28, 32, 52, 56, 60, 12, 36, 84, 88]));
+  expect(masterMask.maskAtTolerance(4)).toEqual(
+      new Set<number>([24, 28, 32, 52, 56, 60, 12, 36, 84, 88, 4, 8,
+      76, 108, 112, 0, 16, 48, 64, 80, 92, 104, 116]));
+  expect(masterMask.maskAtTolerance(0)).toEqual(
+      new Set<number>([24, 28, 32, 52, 56, 60]));
+  // Bounds-behavior (upper bound)
+  expect(masterMask.maskAtTolerance(100)).toEqual(
+      new Set<number>([24, 28, 32, 52, 56, 60, 12, 36, 84, 88, 4, 8,
+      76, 108, 112, 0, 16, 48, 64, 80, 92, 104, 116]));
+  // Bounds-behavior (lower bound)
+  expect(masterMask.maskAtTolerance(-7)).toEqual(
+      new Set<number>([]));
+  });
+
+  function makeImageExampleA(): ImageData {
+  let imgData: ImageData = new ImageData(6, 5);
+  const redSet = new Set<number>([0, 16, 44, 48, 64, 80, 92, 96, 104, 116]);
+  const blueSet = new Set<number>([4, 8, 20, 76, 108, 112]);
+  const greenSet = new Set<number>([12, 36, 72, 84, 88, 100]);
+
+  imgData = setImageColors(
+    imgData,
+    redSet,
+    RED);
+  imgData = setImageColors(
+    imgData,
+    blueSet,
+    BLUE);
+  imgData = setImageColors(imgData,
+    greenSet,
+    GREEN);
+
+  return imgData;
+  }
 });
 
 /** Make an ImageData object that sets pixels in @notMask to Rgba of
@@ -156,17 +222,45 @@ describe('MagicWandService', () => {
 * @newColor should contain new Rgba values in format: [R, G, B, A]
 */
 function makeTestImage(width: number, height: number, newColor: Array<number>,
-   notMask: Set<number>): ImageData {
- const imgData: ImageData = new ImageData(width, height);
- for (const redIndex of notMask) {
-   const red: number = redIndex;
-   const green: number = redIndex + 1;
-   const blue: number = redIndex + 2;
-   const alpha: number = redIndex + 3;
-   imgData.data[red] = newColor[0];
-   imgData.data[green] = newColor[1];
-   imgData.data[blue] = newColor[2];
-   imgData.data[alpha] = newColor[3];
- }
- return imgData;
+    notMask: Set<number>): ImageData {
+  const imgData: ImageData = new ImageData(width, height);
+  for (const redIndex of notMask) {
+    const red: number = redIndex;
+    const green: number = redIndex + 1;
+    const blue: number = redIndex + 2;
+    const alpha: number = redIndex + 3;
+    imgData.data[red] = newColor[0];
+    imgData.data[green] = newColor[1];
+    imgData.data[blue] = newColor[2];
+    imgData.data[alpha] = newColor[3];
+  }
+  return imgData;
 }
+
+/**Change colors in
+* @param {ImageData} imgData at
+* @param {Set<number>} pixelsToChange to a new
+* @param {Color} color
+* */
+function setImageColors(imgData: ImageData,
+    pixelsToChange: Set<number>, color: Color): ImageData {
+  for (let redIndex of pixelsToChange) {
+    const red: number = redIndex;
+    const green: number = redIndex + 1;
+    const blue: number = redIndex + 2;
+    const alpha: number = redIndex + 3;
+    imgData.data[red] = color.red;
+    imgData.data[green] = color.green;
+    imgData.data[blue] = color.blue;
+    imgData.data[alpha] = 255;
+  }
+
+  return imgData;
+}
+
+interface Color {
+ red: number,
+ green: number,
+ blue: number
+}
+

--- a/src/main/ngapp/accio/src/app/editor/magic-wand.service.ts
+++ b/src/main/ngapp/accio/src/app/editor/magic-wand.service.ts
@@ -47,7 +47,6 @@ export class MagicWandService {
     return !visited.has(index);
   }
 
-
   /**@returns {Color} color attributes of the pixel at
   * @param {number} xCoord and
   * @param {number} yCoord based off of the original image supplied by
@@ -123,7 +122,7 @@ export class MagicWandService {
   * percolates from the first-selected pixel.
   */
   scribbleFloodfill(imgData: ImageData, xCoord: number, yCoord: number,
-                    tolerance: number, scribbles: Set<number>): Set<number> {
+      tolerance: number, scribbles: Set<number>): Set<number> {
     return this.doFloodfill(imgData, xCoord, yCoord, tolerance, scribbles);
   }
 
@@ -261,10 +260,158 @@ export class MagicWandService {
     const redMean = (a.red + b.red)/2;
     return (2+redMean/256)*dr*dr + 4*dg*dg + (2 + (255 - redMean)/256)*db*db;
   }
+
+
+  /* Code for 'preview' algorithm */
+
+  /**@Returns {Array<Set<number>>} an array containing all the possible masks.
+  * @param {number} toleranceLimit allows the caller to decide how far(color-wise)
+  * they want to search for 'mask-plausible' pixels.
+  **/
+  getAllFloodfills(imgData: ImageData, xCoord: number, yCoord: number,
+              toleranceLimit: number): MasterMask {
+    // Stores a queue of coords for pixels that we need to visit in "visit".
+    const visit: Array<Array<number>> = new Array();
+    // Stores already-visited pixels in "visited" as index formatted numbers
+    // (as opposed to coord format; for Set funcs).
+    const visited: Set<number> = new Set();
+
+    visit.push([xCoord, yCoord]);
+    // Converts [x,y] format coord to 1-D equivalent of
+    // imgData.data (DataArray).
+    const indexAsDataArray: number =
+      this.coordToDataArrayIndex(xCoord, yCoord, imgData.width);
+    visited.add(indexAsDataArray);
+
+    const masterMask: MasterMask = new MasterMask(toleranceLimit);
+
+    // Adds vanilla pixel to the masterMask.
+    const vanillaPixelColor: Color = this.dataArrayToRgb(imgData, xCoord, yCoord);
+    let maskByToleranceN: Set<number> = new Set<number>();
+    // Tolerance values translate to indices in masterMask.masksByTolerance.
+    const initIndex =Math.ceil(Math.sqrt(this.rgbEuclideanDist(
+        this.dataArrayToRgb(imgData, xCoord, yCoord),
+        vanillaPixelColor)));
+    
+    masterMask.masksByTolerance.splice(initIndex, 1, maskByToleranceN);
+    let initMask = masterMask.masksByTolerance[initIndex];
+    initMask.add(this.coordToDataArrayIndex(xCoord, yCoord, imgData.width));
+
+    // From hereon, works with tolerance limit in the squared space.
+    toleranceLimit *= toleranceLimit;
+
+    // Loops over all plausible 'mask-pixels'.
+    // A pixel is plausibly a 'mask-pixel' if the color of the root pixel
+    // that we percolated from is closer in color to the vanilla
+    // pixel than the pixel being evaluated.
+    while (visit.length !== 0) {
+      const coord: Array<number> = visit.pop();
+      // Unpacks coord.
+      const x: number = coord[0];
+      const y: number = coord[1];
+
+      const curPixelColor: Color = this.dataArrayToRgb(imgData, x, y);
+      const curColorDist: number = 
+          this.rgbEuclideanDist(curPixelColor, vanillaPixelColor);
+
+      // Gets coords of adjacent pixels.
+      const neighbors: Array<Array<number>> =
+        [[x - 1, y], [x + 1, y], [x, y - 1], [x, y + 1]];
+      // Adds coords of adjacent pixels to the heap.
+      for (const neighborPixel of neighbors) {
+        const neighborX: number = neighborPixel[0];
+        const neighborY: number = neighborPixel[1];
+        // Checks if coord is in bounds and has not been visited first.
+        if (!this.getIsValid(
+            imgData.width, imgData.height, neighborX, neighborY, visited)) {
+          continue;
+        }
+
+        const neighborPixelColor: Color = 
+            this.dataArrayToRgb(imgData, neighborX, neighborY);
+        const neighborColorDist: number = 
+            this.rgbEuclideanDist(neighborPixelColor, vanillaPixelColor);
+
+        // Sets a limit to how far (color-wise) we search the image
+        // for 'mask-pixels'.
+        if (neighborColorDist > toleranceLimit) {
+          continue;
+        }
+
+        // If current pixel's color is farther away from the vanilla pixel than
+        // neighbor's color is from the vanilla pixel, then
+        // don't add it to the masterMask.
+        if (curColorDist <= neighborColorDist) {
+          // Adds neighbor pixel to masterMask.
+          const toleranceIndex: number = 
+              Math.ceil(Math.sqrt(neighborColorDist));
+
+          if (masterMask.masksByTolerance[toleranceIndex] === undefined) {
+            // Assigns a new set at this index.
+            maskByToleranceN = new Set<number>();
+            masterMask.masksByTolerance[toleranceIndex] = maskByToleranceN;
+          } else {
+            maskByToleranceN = masterMask.masksByTolerance[toleranceIndex];
+          }
+
+          // Adds neighbor pixel index to the set at this index.
+          maskByToleranceN.add(
+            this.coordToDataArrayIndex(neighborX, neighborY, imgData.width));
+
+          // Continues lifespan of the loop.
+          visit.push(neighborPixel);
+          // A pixel is only considered 'visited'
+          // if it has been added to the masterMask.
+          visited.add(this.coordToDataArrayIndex(x, y, imgData.width));
+        }
+      }
+    }  // End of while loop.
+
+    return masterMask;
+  }
+  }
+
+  interface Color {
+  red: number,
+  green: number,
+  blue: number
+  }
+
+  /**Tracks all versions of masks for 'preview' of floodfill.
+  * Versions are based on different tolerance levels.
+  **/
+  export class MasterMask {
+  masksByTolerance: Array<Set<number>> = [];
+  toleranceIndex = -1;
+  presentMask: Set<number> = new Set<number>();
+
+  constructor(toleranceLimit: number) {
+    this.masksByTolerance.fill(undefined, 0, toleranceLimit + 2);
+  }
+
+  public maskAtTolerance(tolerance: number): Set<number> {
+    let action: Set<number>;
+    while (this.toleranceIndex > tolerance) {
+      action = this.masksByTolerance[this.toleranceIndex--];
+
+      if (action === undefined) {
+        continue;
+      }
+      this.presentMask =
+          SetOperator.difference(this.presentMask, action);
+    }
+
+    while (this.toleranceIndex < tolerance) {
+      action = this.masksByTolerance[++this.toleranceIndex];
+
+      if (action === undefined) {
+        continue;
+      }
+      this.presentMask =
+          SetOperator.union(this.presentMask, action);
+    }
+
+    return this.presentMask;
+  }
 }
 
-interface Color {
- red: number,
- green: number,
- blue: number
-}


### PR DESCRIPTION
Implement 'preview' algo for loading preview of all relevant floodfills:
- Percolates from a vanilla pixel(index) and captures all 'mask-plausible' pixels.
  - A pixel is 'mask-plausible' if the color of the root pixel that we are
    currently percolating from is closer in color-distance to the vanilla
    pixel than the pixel being evaluated is.
  - This results in a 'MasterMask' which holds an array.
    - Indices in the array translate to tolerance values/levels.
    - MasterMask is able to give the caller the mask at tolerance N
      by returning a Set of numbers containing all combined sets from
      indices 0 to N inclusive.