### PR TITLE
Preview to frontend

### DIFF
--- a/src/main/ngapp/accio/src/app/app.module.ts
+++ b/src/main/ngapp/accio/src/app/app.module.ts
@@ -4,6 +4,7 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { MatIconModule } from '@angular/material/icon';
 import { MatSliderModule } from '@angular/material/slider';
 import { MatSidenavModule } from '@angular/material/sidenav';
+import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { MatButtonModule } from '@angular/material/button';
 import { MatFormFieldModule } from '@angular/material/form-field';
@@ -51,6 +52,7 @@ import { TopToolbarComponent } from './top-toolbar/top-toolbar.component';
     MatIconModule,
     MatSliderModule,
     MatSidenavModule,
+    MatSnackBarModule,
     MatButtonToggleModule,
     MatButtonModule,
     MatFormFieldModule,

--- a/src/main/ngapp/accio/src/app/editor/editor.component.css
+++ b/src/main/ngapp/accio/src/app/editor/editor.component.css
@@ -30,13 +30,18 @@ canvas {
   cursor: none;
 }
 
+#preview-layer {
+  z-index: 3;
+  pointer-events: none;
+}
+
 #image-layer {
   z-index: 1;
   background-color:white;
 }
 
 #cursor-layer {
-  z-index: 3;
+  z-index: 4;
   pointer-events: none;
 }
 

--- a/src/main/ngapp/accio/src/app/editor/editor.component.html
+++ b/src/main/ngapp/accio/src/app/editor/editor.component.html
@@ -20,7 +20,7 @@
   (invertMaskEvent)="invertMask()"
   (undoRedoEvent)="undoRedo($event)"
   (switchImageEvent)="switchImage($event)"
-  (newToleranceEvent)="updateTolerance($event)">
+  (newToleranceEvent)="updateTolerance($event); updatePreview();">
 </app-top-toolbar>
 
 <mat-drawer-container id="img-editor">
@@ -47,7 +47,12 @@
         (continuePaintEvent)="drawPixel($event)"
         (newMaskControllerEvent)="newMaskController($event)"
         (newMouseMoveEvent)="setCursorPosition($event)"
-        (newMouseOutEvent)="setCursorOut()">
+        (newMouseOutEvent)="setCursorOut()"
+        (newMouseDownEvent)="endPreview()">
+      </canvas>
+
+      <canvas #previewCanvas id="preview-layer"
+        width="100px" height="100px">
       </canvas>
 
       <canvas #cursorCanvas id="cursor-layer"

--- a/src/main/ngapp/accio/src/app/editor/editor.component.html
+++ b/src/main/ngapp/accio/src/app/editor/editor.component.html
@@ -47,8 +47,7 @@
         (continuePaintEvent)="drawPixel($event)"
         (newMaskControllerEvent)="newMaskController($event)"
         (newMouseMoveEvent)="setCursorPosition($event)"
-        (newMouseOutEvent)="setCursorOut()"
-        (newMouseDownEvent)="endPreview()">
+        (newMouseOutEvent)="setCursorOut()">
       </canvas>
 
       <canvas #previewCanvas id="preview-layer"

--- a/src/main/ngapp/accio/src/app/editor/editor.component.ts
+++ b/src/main/ngapp/accio/src/app/editor/editor.component.ts
@@ -718,7 +718,7 @@ export class EditorComponent implements OnInit {
       }
       this.drawMask();
       this.disableSubmit = this.disableFloodFill = false;
-      }
+    }
   }
 
   // User must confirm the preview and commit it to the mask before 

--- a/src/main/ngapp/accio/src/app/editor/editor.component.ts
+++ b/src/main/ngapp/accio/src/app/editor/editor.component.ts
@@ -784,7 +784,7 @@ export class EditorComponent implements OnInit {
       this.drawMask();
       this.disableSubmit = this.disableFloodFill = false;
 
-      // Unpauses other canvas-editting sequences from registering
+      // Unpauses other canvas-editing sequences from registering
       // on the canvas. 
       const previewLayer = document.getElementById('preview-layer');
       previewLayer.style.pointerEvents = 'none';

--- a/src/main/ngapp/accio/src/app/editor/editor.component.ts
+++ b/src/main/ngapp/accio/src/app/editor/editor.component.ts
@@ -762,8 +762,6 @@ export class EditorComponent implements OnInit {
       this.continuePreview = false;
       this.clearPreviewCanvas();
 
-      let alphaValue = this.maskTool == MaskTool.MAGIC_WAND_ADD ? 255 : 0;
-
       for (let pixel of this.previewMaster.getMaskAsArray()) {
         this.maskImageData.data[pixel] = 255;
         this.maskImageData.data[pixel + 2] = 255;

--- a/src/main/ngapp/accio/src/app/editor/editor.component.ts
+++ b/src/main/ngapp/accio/src/app/editor/editor.component.ts
@@ -112,7 +112,7 @@ export class EditorComponent implements OnInit {
   // Overlays a layer just for showing the preview of the mask.
   // Once the preview is committed, this canvas is cleared and 
   // the chosen preview is painted on the scaledCanvas as well 
-  // as committed to the maskCanavs.
+  // as committed to the maskCanvas.
   @ViewChild('previewCanvas', { static: true })
   previewCanvas: ElementRef<HTMLCanvasElement>;
   private previewCtx: CanvasRenderingContext2D;

--- a/src/main/ngapp/accio/src/app/editor/editor.component.ts
+++ b/src/main/ngapp/accio/src/app/editor/editor.component.ts
@@ -699,6 +699,9 @@ export class EditorComponent implements OnInit {
       // is initiated. 
       this.continuePreview = true;
       this.updatePreview();
+
+      // Pops up a snackbar to tell the user what to do next.
+      this.openPreviewSnackBar();
     } else {
       // Case 2: Performs scribble floodfill sequence.
       let alphaValue = this.maskTool == MaskTool.MAGIC_WAND_ADD ? 255 : 0;
@@ -717,6 +720,22 @@ export class EditorComponent implements OnInit {
       this.disableSubmit = this.disableFloodFill = false;
       }
   }
+
+  // User must confirm the preview and commit it to the mask before 
+  // the preview-sequence can end.
+  openPreviewSnackBar() {
+    let snackBarRef = this.snackBar.open(
+        /*message=*/'Blocking: Please confirm the floodfill on this preview!',
+        /*action-message=*/'Confirm!',
+        { horizontalPosition: 'left',
+          verticalPosition: 'top'}
+        );
+    
+    snackBarRef.afterDismissed().subscribe(() => {
+      this.endPreview();
+    });
+  }
+
   /**Called whenever tolerance input changes. Only executes on a new 
    * preview mask event;
    * newMaskEvent >> floodfillMask() { execute: else block }.
@@ -750,6 +769,8 @@ export class EditorComponent implements OnInit {
         this.maskImageData.data[pixel + 2] = 255;
         this.maskImageData.data[pixel + 3] = 255;
       }
+
+      this.previewMaster.resetMask();
       if (this.curMaskAction.getActionType() == Action.SUBTRACT) {
         this.maskControllerService.do(this.curMaskAction, this.allPixels);
       } else {

--- a/src/main/ngapp/accio/src/app/editor/editor.component.ts
+++ b/src/main/ngapp/accio/src/app/editor/editor.component.ts
@@ -682,7 +682,7 @@ export class EditorComponent implements OnInit {
   floodfillMask(maskAction: MaskAction): void {
     this.disableSubmit = this.disableFloodFill = true;
     // Case 1: performs preview-floodfill sequence.
-    if (maskAction.previewMaster.masksByTolerance !== undefined) {
+    if (maskAction.previewMaster.getIsPreview()) {
       // Pauses any other canvas-editting sequences from registering
       // on the canvas. 
       const previewLayer = document.getElementById('preview-layer');

--- a/src/main/ngapp/accio/src/app/editor/editor.component.ts
+++ b/src/main/ngapp/accio/src/app/editor/editor.component.ts
@@ -770,6 +770,11 @@ export class EditorComponent implements OnInit {
         this.maskImageData.data[pixel + 3] = 255;
       }
 
+      // Updates curMaskAction to hold the changedPixels,
+      // and pass them into maskController.
+      this.curMaskAction.commitPreviewPixels(
+        this.previewMaster.getMaskAsSet()
+      );
       this.previewMaster.resetMask();
       if (this.curMaskAction.getActionType() == Action.SUBTRACT) {
         this.maskControllerService.do(this.curMaskAction, this.allPixels);

--- a/src/main/ngapp/accio/src/app/editor/editor.component.ts
+++ b/src/main/ngapp/accio/src/app/editor/editor.component.ts
@@ -801,7 +801,7 @@ export class EditorComponent implements OnInit {
       } else {
         this.maskControllerService.do(maskAction);
       }
-      this.drawMask();
+      this.drawMask(this.destinationCoords.x, this.destinationCoords.y);
       this.disableSubmit = this.disableFloodFill = false;
     }
   }
@@ -864,7 +864,7 @@ export class EditorComponent implements OnInit {
       } else {
         this.maskControllerService.do(this.curMaskAction);
       }
-      this.drawMask();
+      this.drawMask(this.destinationCoords.x, this.destinationCoords.y);
       this.disableSubmit = this.disableFloodFill = false;
 
       // Unpauses other canvas-editing sequences from registering

--- a/src/main/ngapp/accio/src/app/editor/magic-wand.service.ts
+++ b/src/main/ngapp/accio/src/app/editor/magic-wand.service.ts
@@ -309,6 +309,11 @@ export class MagicWandService {
       // This if statement limits the size of the priority queue for 
       // reasonable runtime performance in the browser. Removing this 
       // may cause the browser to become unresponsive for big previews.
+      // When the limit is reached, the algorithm returns the 
+      // shortest distances that it has calculated so far. If the user
+      // changes the tolerance input to a higher tolerance than what was 
+      // calcualted within this limit, then the distances up to the highest 
+      // calculated tolerance will be returned.
       if (toVisit.getSize() > 600000) {
         return distances;
       }

--- a/src/main/ngapp/accio/src/app/editor/magic-wand.service.ts
+++ b/src/main/ngapp/accio/src/app/editor/magic-wand.service.ts
@@ -407,7 +407,7 @@ export class PreviewMask {
    * the given 
    * @param {number} tolerance level.
    */
-  public maskAtTolerance(tolerance: number): Set<number> {
+  public changeMaskBy(tolerance: number): void {
     if (tolerance < 0) {
       throw new Error('Tolerance input must be a non-negative number...');
     }
@@ -434,7 +434,9 @@ export class PreviewMask {
         this.presentMask.push(pixelIndex);
       });
     }
+  }
 
+  public getMask(): Set<number> {
     return new Set<number>(this.presentMask);
   }
 }

--- a/src/main/ngapp/accio/src/app/editor/magic-wand.service.ts
+++ b/src/main/ngapp/accio/src/app/editor/magic-wand.service.ts
@@ -398,8 +398,12 @@ export class PreviewMask {
   masksByTolerance: Array<Array<number>> = [];
   private toleranceIndex = -1;
   private presentMask: Array<number> = [];
+  private isPreview = true;
 
   constructor(toleranceLimit: number) {
+    if (toleranceLimit === -1) {
+      this.isPreview = false;
+    }
     this.masksByTolerance.fill(undefined, 0, toleranceLimit + 2);
   }
 
@@ -450,5 +454,9 @@ export class PreviewMask {
     this.masksByTolerance[this.toleranceIndex--].forEach(() => {
       this.presentMask.pop();
     })
+  }
+
+  public getIsPreview(): boolean {
+    return this.isPreview;
   }
 }

--- a/src/main/ngapp/accio/src/app/editor/magic-wand.service.ts
+++ b/src/main/ngapp/accio/src/app/editor/magic-wand.service.ts
@@ -305,6 +305,12 @@ export class MagicWandService {
 
     // Updates shortest path between neighbor pixel and vanilla node.
     while (toVisit.getSize() !== 0) {
+      // This if statement limits the size of the priority queue for 
+      // reasonable runtime performance in the browser. Removing this 
+      // may cause the browser to become unresponsive for big previews.
+      if (toVisit.getSize() > 600000) {
+        return distances;
+      }
       const curPixelNode: PixelNode = toVisit.pop();
       // A node is considered visited once popped.
       visited.add(curPixelNode.index);

--- a/src/main/ngapp/accio/src/app/editor/magic-wand.service.ts
+++ b/src/main/ngapp/accio/src/app/editor/magic-wand.service.ts
@@ -443,4 +443,12 @@ export class PreviewMask {
   public getMaskAsArray(): Array<number> {
     return this.presentMask;
   }
+
+  public resetMask(): void {
+    this.changeMaskBy(0);
+
+    this.masksByTolerance[this.toleranceIndex--].forEach(() => {
+      this.presentMask.pop();
+    })
+  }
 }

--- a/src/main/ngapp/accio/src/app/editor/magic-wand.service.ts
+++ b/src/main/ngapp/accio/src/app/editor/magic-wand.service.ts
@@ -382,7 +382,7 @@ export class MagicWandService {
 
     for (let i = 0; i < imgData.data.length / 4; i++) {
       // Reducing tolerance to the root reduces the number of iterations
-      // inside PreviewMask.masksAtTolerance()
+      // inside PreviewMask.changeMaskBy()
       tolerance = Math.ceil(Math.sqrt(shortestPaths[i]));
       if (previewMask.masksByTolerance[tolerance] === undefined) {
         previewMask.masksByTolerance[tolerance] = [];

--- a/src/main/ngapp/accio/src/app/editor/magic-wand.service.ts
+++ b/src/main/ngapp/accio/src/app/editor/magic-wand.service.ts
@@ -396,8 +396,8 @@ interface PixelNode {
    **/
 export class PreviewMask {
   masksByTolerance: Array<Array<number>> = [];
-  toleranceIndex = -1;
-  presentMask: Array<number> = [];
+  private toleranceIndex = -1;
+  private presentMask: Array<number> = [];
 
   constructor(toleranceLimit: number) {
     this.masksByTolerance.fill(undefined, 0, toleranceLimit + 2);
@@ -436,7 +436,11 @@ export class PreviewMask {
     }
   }
 
-  public getMask(): Set<number> {
+  public getMaskAsSet(): Set<number> {
     return new Set<number>(this.presentMask);
+  }
+
+  public getMaskAsArray(): Array<number> {
+    return this.presentMask;
   }
 }

--- a/src/main/ngapp/accio/src/app/editor/mask-action.ts
+++ b/src/main/ngapp/accio/src/app/editor/mask-action.ts
@@ -31,7 +31,7 @@ export class MaskAction {
      *   CLEAR: the pixels of the current mask
      */
     private changedPixels: Set<number>,
-    public previewMaster: PreviewMask = undefined
+    public previewMaster: PreviewMask = new PreviewMask(-1)
   ) {}
 
   public getActionType(): Action {

--- a/src/main/ngapp/accio/src/app/editor/mask-action.ts
+++ b/src/main/ngapp/accio/src/app/editor/mask-action.ts
@@ -1,5 +1,6 @@
 import { SetOperator } from './set-operator';
 import { Move } from './mask-controller.service';
+import { PreviewMask } from './magic-wand.service';
 
 export enum Action {
   ADD = 'add',
@@ -29,7 +30,8 @@ export class MaskAction {
      *   INVERT: every pixel of the image
      *   CLEAR: the pixels of the current mask
      */
-    private changedPixels: Set<number>
+    private changedPixels: Set<number>,
+    public previewMaster: PreviewMask = undefined
   ) {}
 
   public getActionType(): Action {

--- a/src/main/ngapp/accio/src/app/editor/mask-action.ts
+++ b/src/main/ngapp/accio/src/app/editor/mask-action.ts
@@ -46,6 +46,10 @@ export class MaskAction {
     return this.changedPixels;
   }
 
+  public commitPreviewPixels(mask: Set<number>): void {
+    this.changedPixels = mask;
+  }
+
   /**
    * Does or undoes the action.
    * @param     {Move}          direction

--- a/src/main/ngapp/accio/src/app/editor/mask.directive.ts
+++ b/src/main/ngapp/accio/src/app/editor/mask.directive.ts
@@ -187,9 +187,7 @@ export class MaskDirective {
         this.tool == MaskTool.MAGIC_WAND_SUB) &&
       !this.scribbleFill
     ) {
-      // TODO: Implement Quick-floodfill option; replace boolean false with
-      // a variable to trigger quick-floodfill.
-      if (false) {
+      if (this.tool == MaskTool.MAGIC_WAND_SUB) {
         // Returns an array indices of each pixel in the mask.
         const maskPixels = this.magicWandService.floodfill(
           this.originalImageData,
@@ -200,9 +198,7 @@ export class MaskDirective {
 
         this.newMaskEvent.emit(
           new Mask.MaskAction(
-            this.tool == MaskTool.MAGIC_WAND_ADD
-              ? Mask.Action.ADD
-              : Mask.Action.SUBTRACT,
+            Mask.Action.SUBTRACT,
             Mask.Tool.MAGIC_WAND,
             maskPixels
           )
@@ -210,6 +206,7 @@ export class MaskDirective {
       } else {  // Default: does preview-style floodfill
         // TODO: Let user decide tolerance limit
         // (replace hardcoded val 300 with a var).
+        // TODO: Implement Quick-floodfill option (for);
         const previewMaster: PreviewMask = 
             this.magicWandService.getPreviews(
               this.originalImageData,
@@ -218,16 +215,14 @@ export class MaskDirective {
               /* toleranceLimit= */300
             );
 
-            this.newMaskEvent.emit(
-              new Mask.MaskAction(
-                this.tool == MaskTool.MAGIC_WAND_ADD
-                  ? Mask.Action.ADD
-                  : Mask.Action.SUBTRACT,
-                Mask.Tool.MAGIC_WAND,
-                undefined,
-                previewMaster
-              )
-            )
+        this.newMaskEvent.emit(
+          new Mask.MaskAction(
+            Mask.Action.ADD,
+            Mask.Tool.MAGIC_WAND,
+            undefined,
+            previewMaster
+          )
+        );
       }
 
     }

--- a/src/main/ngapp/accio/src/app/editor/mask.directive.ts
+++ b/src/main/ngapp/accio/src/app/editor/mask.directive.ts
@@ -227,16 +227,6 @@ export class MaskDirective {
           )
         );
       }
-
-      this.newMaskEvent.emit(
-        new Mask.MaskAction(
-          this.tool == MaskTool.MAGIC_WAND_ADD
-            ? Mask.Action.ADD
-            : Mask.Action.SUBTRACT,
-          Mask.Tool.MAGIC_WAND,
-          maskPixels
-        )
-      );
     } else if (this.tool == MaskTool.PAN) {
       const offsetCoord = this.convertToUnscaledCoord(e.offsetX, e.offsetY);
       this.newDestinationEvent.emit(this.getPanDestinationCoord(offsetCoord));

--- a/src/main/ngapp/accio/src/app/editor/mask.directive.ts
+++ b/src/main/ngapp/accio/src/app/editor/mask.directive.ts
@@ -217,7 +217,17 @@ export class MaskDirective {
               this.coord[1],
               /* toleranceLimit= */300
             );
-          
+
+            this.newMaskEvent.emit(
+              new Mask.MaskAction(
+                this.tool == MaskTool.MAGIC_WAND_ADD
+                  ? Mask.Action.ADD
+                  : Mask.Action.SUBTRACT,
+                Mask.Tool.MAGIC_WAND,
+                undefined,
+                previewMaster
+              )
+            )
       }
 
     }

--- a/src/main/ngapp/accio/src/app/top-toolbar/top-toolbar.component.html
+++ b/src/main/ngapp/accio/src/app/top-toolbar/top-toolbar.component.html
@@ -29,7 +29,7 @@
     <mat-slider 
       title="Mask Tolerance    ↓1  2↑"  
       (change)="updateTolerance()"
-      min="1" max="127.5" step=".5" [(ngModel)]="toleranceValue">
+      min="1" max="420" step="1" [(ngModel)]="toleranceValue">
     </mat-slider>
     <mat-form-field class="slider-value">
       <mat-label style="color=white">Tolerance</mat-label>

--- a/src/main/ngapp/accio/src/app/top-toolbar/top-toolbar.component.html
+++ b/src/main/ngapp/accio/src/app/top-toolbar/top-toolbar.component.html
@@ -28,7 +28,7 @@
     Tolerance
     <mat-slider 
       title="Mask Tolerance    ↓1  2↑"  
-      (change)="updateTolerance()"
+      (input)="updateTolerance()"
       min="1" max="420" step="1" [(ngModel)]="toleranceValue">
     </mat-slider>
     <mat-form-field class="slider-value">

--- a/src/main/ngapp/accio/src/app/top-toolbar/top-toolbar.component.html
+++ b/src/main/ngapp/accio/src/app/top-toolbar/top-toolbar.component.html
@@ -28,15 +28,14 @@
     Tolerance
     <mat-slider 
       title="Mask Tolerance    ↓1  2↑"  
-      (input)="updateTolerance()"
-      min="1" max="420" step="1" [(ngModel)]="toleranceValue">
+      (input)="updateTolerance($event)"
+      min="1" max="420" step="1">
     </mat-slider>
     <mat-form-field class="slider-value">
       <mat-label style="color=white">Tolerance</mat-label>
       <input
-        (change)="updateTolerance()" 
-        matInput type="number" 
-        [(ngModel)]="toleranceValue" 
+        (change)="updateTolerance($event)" 
+        matInput type="number"
         style="color=white">
     </mat-form-field>
   </span>

--- a/src/main/ngapp/accio/src/app/top-toolbar/top-toolbar.component.html
+++ b/src/main/ngapp/accio/src/app/top-toolbar/top-toolbar.component.html
@@ -28,7 +28,7 @@
     Tolerance
     <mat-slider 
       title="Mask Tolerance    ↓1  2↑"  
-      (input)="updateTolerance()"
+      (input)="updateTolerance($event)"
       [(ngModel)]="toleranceValue" 
       min="1" max="420" step="1">
     </mat-slider>

--- a/src/main/ngapp/accio/src/app/top-toolbar/top-toolbar.component.html
+++ b/src/main/ngapp/accio/src/app/top-toolbar/top-toolbar.component.html
@@ -28,14 +28,16 @@
     Tolerance
     <mat-slider 
       title="Mask Tolerance    ↓1  2↑"  
-      (input)="updateTolerance($event)"
+      (input)="updateTolerance()"
+      [(ngModel)]="toleranceValue" 
       min="1" max="420" step="1">
     </mat-slider>
     <mat-form-field class="slider-value">
       <mat-label style="color=white">Tolerance</mat-label>
       <input
-        (change)="updateTolerance($event)" 
-        matInput type="number"
+        (change)="updateTolerance()" 
+        matInput type="number" 
+        [(ngModel)]="toleranceValue" 
         style="color=white">
     </mat-form-field>
   </span>

--- a/src/main/ngapp/accio/src/app/top-toolbar/top-toolbar.component.ts
+++ b/src/main/ngapp/accio/src/app/top-toolbar/top-toolbar.component.ts
@@ -1,5 +1,6 @@
 import { HostListener, Component, OnInit } from '@angular/core';
 import { Output, EventEmitter } from '@angular/core';
+import { MatSliderChange } from '@angular/material/slider';
 
 @Component({
   selector: 'app-top-toolbar',
@@ -82,7 +83,11 @@ export class TopToolbarComponent implements OnInit {
   }
 
   /** Emits value of user inputed/slider tolerance. */
-  updateTolerance() {
+  updateTolerance(event: MatSliderChange = undefined) {
+    // Updates the toleranceValue as the slider is being moved.
+    if (event !== undefined) {
+      this.toleranceValue = event.value;
+    }
     this.newToleranceEvent.emit(this.toleranceValue);
   }
 }

--- a/src/main/ngapp/accio/src/app/top-toolbar/top-toolbar.component.ts
+++ b/src/main/ngapp/accio/src/app/top-toolbar/top-toolbar.component.ts
@@ -42,12 +42,12 @@ export class TopToolbarComponent implements OnInit {
         case 49:
           console.log('1');
           this.toleranceValue = Math.max(this.toleranceValue - 1, 0.0);
-          this.updateTolerance();
+          this.newToleranceEvent.emit(this.toleranceValue);
           break;
         case 50:
           console.log('2');
           this.toleranceValue = Math.min(this.toleranceValue + 1, 127.5);
-          this.updateTolerance();
+          this.newToleranceEvent.emit(this.toleranceValue);
           break;
       }
     }

--- a/src/main/ngapp/accio/src/app/top-toolbar/top-toolbar.component.ts
+++ b/src/main/ngapp/accio/src/app/top-toolbar/top-toolbar.component.ts
@@ -1,5 +1,6 @@
 import { HostListener, Component, OnInit } from '@angular/core';
 import { Output, EventEmitter } from '@angular/core';
+import { MatSliderChange } from '@angular/material/slider';
 
 @Component({
   selector: 'app-top-toolbar',
@@ -82,7 +83,8 @@ export class TopToolbarComponent implements OnInit {
   }
 
   /** Emits value of user inputed/slider tolerance. */
-  updateTolerance() {
+  updateTolerance(event: MatSliderChange) {
+    this.toleranceValue = event.value;
     this.newToleranceEvent.emit(this.toleranceValue);
   }
 }

--- a/src/main/ngapp/accio/src/app/top-toolbar/top-toolbar.component.ts
+++ b/src/main/ngapp/accio/src/app/top-toolbar/top-toolbar.component.ts
@@ -1,6 +1,5 @@
 import { HostListener, Component, OnInit } from '@angular/core';
 import { Output, EventEmitter } from '@angular/core';
-import { MatSliderChange } from '@angular/material/slider';
 
 @Component({
   selector: 'app-top-toolbar',
@@ -42,12 +41,12 @@ export class TopToolbarComponent implements OnInit {
         case 49:
           console.log('1');
           this.toleranceValue = Math.max(this.toleranceValue - 1, 0.0);
-          this.newToleranceEvent.emit(this.toleranceValue);
+          this.updateTolerance();
           break;
         case 50:
           console.log('2');
           this.toleranceValue = Math.min(this.toleranceValue + 1, 127.5);
-          this.newToleranceEvent.emit(this.toleranceValue);
+          this.updateTolerance();
           break;
       }
     }
@@ -56,7 +55,7 @@ export class TopToolbarComponent implements OnInit {
   constructor() {}
 
   ngOnInit(): void {
-    this.toleranceValue = 30;
+    this.toleranceValue = 15;
   }
 
   /** Called when user clicks clear mask button. */
@@ -83,8 +82,7 @@ export class TopToolbarComponent implements OnInit {
   }
 
   /** Emits value of user inputed/slider tolerance. */
-  updateTolerance(event: MatSliderChange) {
-    this.toleranceValue = event.value;
+  updateTolerance() {
     this.newToleranceEvent.emit(this.toleranceValue);
   }
 }


### PR DESCRIPTION
### **IMPORTANT**: _Shortest paths algo fails in the chrome browser to execute on some images. The page hangs and dies before it finishes executing._
  - I don't know if this is a case of the image solely being too big or also about color-distribution in the image. The algo runs in 8 -12 seconds for an image of 1,000,000 pixels, but fails on an image of 960,000 pixels, so it'probably not due to the image size. 
  ### - Possibilities:
  - This might be a problem with the priority queue adding too many neighbors.
    - CURRENT WORKAROUND: Putting a hard limit on the size of the priority queue allows the algo to run successfully in the browser.
    - @dtjanaka @shmcaffrey feel free to play around with adjusting this hardcoded value. It is in the magicwandservice typescript file, in the while loop of the getShortestPaths() method 

### 8|28|2020(approx)
Implement preview floodfill algo for user-interaction
- Revamp tolerance slider so that it updates real-time as the user is in the process of sliding it.
- Update **PreviewMask class** to handle providing more data for editor.component.
  - **masksAtTolerance()** => **changeMaskBy()**
    - Make void
      - no longer converts the present mask into a new set each time; caller does not necessarily want the set after every call to this function
  - Make **new getter methods** for:
    - getting the present mask as it is (an array)
    - getting the present mask as a set
    - getting a boolean to check if the PreviewMask object has been initialized properly
      - Used by caller to check if they should perform a preview-floodfills or normal floodfill sequence
  - Add **resetMask()**
    - Allows caller to reset this.presentMask to an empty array and also reset this object's tolerance-index-pointer
- Changes to mask action file:
  - Update mask action class to handle passing PreviewMask as data to the editor component
- Changes to mask directive:
  - No longer emitts basic floodfill actions; replaced with preview-floodfill
    - Might want to re-enable basic floodfill later, because it is a lot faster to execute that algo. vs preview-floodfill algo.
    - Still emits scribble floodfill action
    - Still capable of floodfill-subtraction action

### 8|29|2020(approx)
- Changes to app module file:
  - Add import and declaration for snackbar module
- Add new canvas '**previewCanvas**' to editor component
  - Draw the preview separately from the scaledCanvas so that they user can see the new previews of floodfills at different tolerance levels
  - **updatePreview()** and **drawPreview()** methods are used to redraw the previewed-mask at the current user-inputted tolerance each time that the user changes the tolerance (using either the slider or number input next to the slider)
    - updatePreview() triggers the preview-snackbar to pop-up
      - Instruct the user to click 'confirm' on the snackbar if they want to commit the previewed-floodfill
        - Clicking the 'confirm' action on the snackbar triggers **endPreview()**
          - Commit the previewed floodfill at the current tolerance-input into the maskController aka undo/redo logic-flow
      - Block the user from starting another action (point-events stop working on the canvas area) until they press "confirm" on the snackbar